### PR TITLE
Update Jetty to 9.4.46.v20220331

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # Jetty >=10 requires Java 11+
+      - dependency-name: "org.eclipse.jetty:*"
+        versions: [">= 10.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,6 @@
     </developer>
   </developers>
 
-  <prerequisites>
-    <maven>${mavenVersion}</maven>
-  </prerequisites>
-
   <modules>
     <module>mrm-api</module>
     <module>mrm-servlet</module>
@@ -89,7 +85,7 @@
     <scmpublish.content>target/staging/mrm</scmpublish.content>
     <mavenVersion>2.2.1</mavenVersion>
     <mojo.java.target>1.8</mojo.java.target>
-    <jetty.version>9.4.43.v20210629</jetty.version>
+    <jetty.version>9.4.46.v20220331</jetty.version>
     <project.build.outputTimestamp>2022-01-18T09:14:02Z</project.build.outputTimestamp>
   </properties>
 


### PR DESCRIPTION
This will also tell dependabot to ignore Jetty versions from 10.x