### PR TITLE
basePath configuration parameter

### DIFF
--- a/mrm-maven-plugin/src/it/custom-base-path/pom.xml
+++ b/mrm-maven-plugin/src/it/custom-base-path/pom.xml
@@ -2,12 +2,12 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <groupId>org.mojohaus.mrm.its</groupId>
-  <artifactId>hostedrepo</artifactId>
+  <artifactId>custom-base-path</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  
+
   <build>
     <plugins>
       <plugin>
@@ -28,6 +28,7 @@
           <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
           <settingsFile>src/it/settings.xml</settingsFile>
           <filterProperties>
+            <maven-compiler-plugin.version>@maven-compiler-plugin.version@</maven-compiler-plugin.version>
             <mrm.distribution.url>${mrm.distribution.url}</mrm.distribution.url>
             <mrm.repository.url>${mrm.repository.url}</mrm.repository.url>
           </filterProperties>
@@ -42,26 +43,14 @@
         <version>@project.version@</version>
         <executions>
           <execution>
-            <id>distribution</id>
-            <goals>
-              <goal>start</goal>
-              <goal>stop</goal>
-            </goals>
-            <configuration>
-              <propertyName>mrm.distribution.url</propertyName>
-              <repositories>
-                <hostedRepo>
-                  <target>${project.build.directory}/hosted-repo</target>
-                </hostedRepo>
-              </repositories>
-            </configuration>
-          </execution>
-          <execution>
             <id>repository</id>
             <goals>
               <goal>start</goal>
               <goal>stop</goal>
             </goals>
+            <configuration>
+              <basePath>/foo/bar</basePath>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/mrm-maven-plugin/src/it/custom-base-path/src/it/resolve/invoker.properties
+++ b/mrm-maven-plugin/src/it/custom-base-path/src/it/resolve/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = test

--- a/mrm-maven-plugin/src/it/custom-base-path/src/it/resolve/pom.xml
+++ b/mrm-maven-plugin/src/it/custom-base-path/src/it/resolve/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.mojohaus.mrm.hostedrepo.its</groupId>
+  <artifactId>mrm-resolve</artifactId>
+  <version>1.0.0</version>
+  <packaging>jar</packaging>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>${maven.compiler.source}</maven.compiler.target>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.8.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>5.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.22.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>@maven-compiler-plugin.version@</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.2</version>
+        <configuration>
+          <systemPropertyVariables>
+            <mrm.repository.url>@mrm.repository.url@</mrm.repository.url>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/mrm-maven-plugin/src/it/custom-base-path/src/it/resolve/src/test/java/org/codehaus/mojo/mrm/plugin/it/resolve/CustomBasePathTest.java
+++ b/mrm-maven-plugin/src/it/custom-base-path/src/it/resolve/src/test/java/org/codehaus/mojo/mrm/plugin/it/resolve/CustomBasePathTest.java
@@ -1,0 +1,44 @@
+package org.codehaus.mojo.mrm.plugin.it.resolve;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.assertj.core.api.Assertions;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import io.restassured.RestAssured;
+
+public class CustomBasePathTest {
+
+    @Test
+    void customBasePath() {
+        final String mrmUri = System.getProperty("mrm.repository.url");
+
+        /* Make sure the repo ends with the base path we have set in mrm-maven-plugin/src/it/custom-base-path/pom.xml */
+        Assertions.assertThat(mrmUri).endsWith("foo/bar");
+
+        /* Try to download something and make sure the content is as expected */
+        RestAssured
+            .get(mrmUri + "/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.pom")
+            .then()
+            .statusCode(200)
+            .body(Matchers.containsString("<artifactId>commons-lang3</artifactId>"), Matchers.containsString("<version>3.12.0</version>"));
+    }
+}

--- a/mrm-maven-plugin/src/it/custom-base-path/src/it/resolve/verify.groovy
+++ b/mrm-maven-plugin/src/it/custom-base-path/src/it/resolve/verify.groovy
@@ -1,0 +1,4 @@
+// mrm-resolve test project depends on assertj, so it should appear in the test's local repo
+assert new File( basedir, '../../local-repo-it/org/assertj/assertj-core/3.22.0/assertj-core-3.22.0.pom').exists()
+// We have downloaded commons-lang3-3.12.0.pom via mrm.repository.url from CustomBasePathTest, so it should appear in the parent local repo
+assert new File( basedir, '../../../../../local-repo/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.pom').exists()

--- a/mrm-maven-plugin/src/it/custom-base-path/src/it/settings.xml
+++ b/mrm-maven-plugin/src/it/custom-base-path/src/it/settings.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings>
+ <mirrors>
+    <mirror>
+      <id>it-repo</id>
+      <url>@mrm.repository.url@</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>http://local.central</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>http://local.central</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <activeProfile>it-repo</activeProfile>
+  </activeProfiles>
+</settings>

--- a/mrm-maven-plugin/src/it/hostedrepo/src/it/local-maven-repo-proxy/invoker.properties
+++ b/mrm-maven-plugin/src/it/hostedrepo/src/it/local-maven-repo-proxy/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = deploy

--- a/mrm-maven-plugin/src/it/hostedrepo/src/it/local-maven-repo-proxy/pom.xml
+++ b/mrm-maven-plugin/src/it/hostedrepo/src/it/local-maven-repo-proxy/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <distributionManagement>
+    <repository>
+      <id>mrm</id>
+      <url>@mrm.distribution.url@</url>
+    </repository>
+  </distributionManagement>
+  
+  <groupId>org.mojohaus.mrm.hostedrepo.its</groupId>
+  <artifactId>deploy</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+
+</project>

--- a/mrm-maven-plugin/src/it/hostedrepo/src/it/local-maven-repo-proxy/verify.groovy
+++ b/mrm-maven-plugin/src/it/hostedrepo/src/it/local-maven-repo-proxy/verify.groovy
@@ -1,0 +1,4 @@
+assert new File( basedir, '../../hosted-repo/org/mojohaus/mrm/hostedrepo/its/deploy/maven-metadata.xml').exists()
+assert new File( basedir, '../../hosted-repo/org/mojohaus/mrm/hostedrepo/its/deploy/1.0.0/deploy-1.0.0.pom').exists()
+assert new File( basedir, '../../hosted-repo/org/mojohaus/mrm/hostedrepo/its/deploy/1.0.0/deploy-1.0.0.pom.md5').exists()
+assert new File( basedir, '../../hosted-repo/org/mojohaus/mrm/hostedrepo/its/deploy/1.0.0/deploy-1.0.0.pom.sha1').exists()

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/AbstractStartMojo.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/AbstractStartMojo.java
@@ -42,6 +42,18 @@ public abstract class AbstractStartMojo
     private int port;
 
     /**
+     * The base path under which the repository will be served.
+     * <p>
+     * By default, {@code org.acme:my-artifact:pom:1.2.3} will be served under
+     * {@code http://localhost:<port>/org/acme/my-artifact/1.2.3/my-artifact-1.2.3.pom}.
+     * <p>
+     * If {@code basePath} is set to e.g. {@code foo/bar} then {@code org.acme:my-artifact:pom:1.2.3} will be served
+     * under {@code http://localhost:<port>/foo/bar/org/acme/my-artifact/1.2.3/my-artifact-1.2.3.pom}.
+     */
+    @Parameter( property = "mrm.basePath", defaultValue = "/" )
+    private String basePath;
+
+    /**
      * The repositories to serve. When more than one repository is specified, a merged repository view
      * of those will be used. If none specified then a proxy of the invoking Maven's repositories will
      * be served.
@@ -59,13 +71,14 @@ public abstract class AbstractStartMojo
     {
         return new FileSystemServer( ArtifactUtils.versionlessKey( project.getGroupId(), project.getArtifactId() ),
                                      Math.max( 0, Math.min( port, 65535 ) ),
-                                     new AutoDigestFileSystem( new ArtifactStoreFileSystem( artifactStore ) ), 
+                                     basePath,
+                                     new AutoDigestFileSystem( new ArtifactStoreFileSystem( artifactStore ) ),
                                      getSettingsServletPath() );
     }
 
     /**
-     * When set, this points to the to the location from where the settings file can be downloaded. 
-     * 
+     * When set, this points to the to the location from where the settings file can be downloaded.
+     *
      * @return the servlet path to the settings file of {@code null}
      */
     protected String getSettingsServletPath()


### PR DESCRIPTION
This adds `basePath` config parameter defined as follows:

```
    /**
     * The base path under which the repository will be served.
     * <p>
     * By default, {@code org.acme:my-artifact:pom:1.2.3} will be served under
     * {@code http://localhost:<port>/org/acme/my-artifact/1.2.3/my-artifact-1.2.3.pom}.
     * <p>
     * If {@code basePath} is set to e.g. {@code foo/bar} then {@code org.acme:my-artifact:pom:1.2.3} will be served
     * under {@code http://localhost:<port>/foo/bar/org/acme/my-artifact/1.2.3/my-artifact-1.2.3.pom}.
     */
    @Parameter( property = "mrm.basePath", defaultValue = "/" )
    private String basePath;
```

On my side, this is motivated by a need to have caching proxy of some company-internal maven repo for a tool (namely [PNC Bacon PiG](https://project-ncl.github.io/bacon/guide/pig.html) ) that only allows configuring the protocol host and port of the repo ([here](https://github.com/project-ncl/bacon/blob/main/config.yaml#L32)), but assumes a fixed base path.