### PR TITLE
Fix unclosed opened stream

### DIFF
--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/ArtifactStoreFileSystem.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/ArtifactStoreFileSystem.java
@@ -126,9 +126,7 @@ public class ArtifactStoreFileSystem
         this.store = store;
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public Entry[] listEntries( DirectoryEntry directory )
     {
         if ( getRoot().equals( directory ) )
@@ -164,7 +162,6 @@ public class ArtifactStoreFileSystem
         String groupId = path.replace( '/', '.' );
 
         // get all the groupId's that start with this groupId
-        String groupIdPrefix = groupId + ".";
         Set<String> groupIds = new TreeSet<>( store.getGroupIds( groupId ) );
         for ( String name : groupIds )
         {
@@ -223,9 +220,7 @@ public class ArtifactStoreFileSystem
         return result.toArray(new Entry[0]);
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     protected Entry get( DirectoryEntry parent, String name )
     {
         String path = "/";
@@ -299,7 +294,8 @@ public class ArtifactStoreFileSystem
                                                       matcher.group( 10 ) );
                     try
                     {
-                        store.get( artifact );
+                        // check if artifact exist
+                        store.getSize( artifact );
                         return new ArtifactFileEntry( this, parent, artifact, store );
                     }
                     catch ( IOException | ArtifactNotFoundException e )
@@ -325,7 +321,8 @@ public class ArtifactStoreFileSystem
                                                       matcher.group( 10 ), timestamp, buildNumber );
                     try
                     {
-                        store.get( artifact );
+                        // check if artifact exist
+                        store.getSize( artifact );
                         return new ArtifactFileEntry( this, parent, artifact, store );
                     }
                     catch ( IOException | ArtifactNotFoundException e )
@@ -360,7 +357,8 @@ public class ArtifactStoreFileSystem
                     Artifact artifact = new Artifact( groupId, artifactId, version, classifier, type );
                     try
                     {
-                        store.get( artifact );
+                        // check if artifact exist
+                        store.getSize( artifact );
                         return new ArtifactFileEntry( this, parent, artifact, store );
                     }
                     catch ( ArtifactNotFoundException | IOException e )
@@ -376,9 +374,7 @@ public class ArtifactStoreFileSystem
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
+    @Override
     public long getLastModified( DirectoryEntry entry )
         throws IOException
     {

--- a/mrm-servlet/src/test/java/org/codehaus/mojo/mrm/impl/maven/ArtifactStoreFileSystemTest.java
+++ b/mrm-servlet/src/test/java/org/codehaus/mojo/mrm/impl/maven/ArtifactStoreFileSystemTest.java
@@ -40,7 +40,6 @@ public class ArtifactStoreFileSystemTest
 
     @Test
     public void testGroupMetadataRegex()
-        throws Exception
     {
         Matcher matcher = ArtifactStoreFileSystem.METADATA.matcher( "/commons/maven-metadata.xml" );
         assertTrue( matcher.matches() );
@@ -56,7 +55,6 @@ public class ArtifactStoreFileSystemTest
 
     @Test
     public void testArtifactRegex()
-        throws Exception
     {
         Matcher matcher = ArtifactStoreFileSystem.ARTIFACT.matcher( "/commons/maven-metadata.xml" );
         assertFalse( matcher.matches() );
@@ -109,7 +107,6 @@ public class ArtifactStoreFileSystemTest
 
     @Test
     public void testSnapshotArtifactRegex()
-        throws Exception
     {
         Matcher matcher = ArtifactStoreFileSystem.SNAPSHOT_ARTIFACT.matcher( "/commons/maven-metadata.xml" );
         assertFalse( matcher.matches() );
@@ -159,7 +156,7 @@ public class ArtifactStoreFileSystemTest
     public void testSiteXmlReleaseVersion() throws Exception
     {
         ArtifactStore store = mock( ArtifactStore.class );
-        when( store.get( isA( Artifact.class ) ) ).thenThrow( ArtifactNotFoundException.class );
+        when( store.getSize( isA( Artifact.class ) ) ).thenThrow( ArtifactNotFoundException.class );
         ArtifactStoreFileSystem system = new ArtifactStoreFileSystem( store );
         FileEntry entry = (FileEntry) system.get( "/localhost/mmockrm-5/1/mmockrm-5-1-site_en.xml" );
         assertNull( entry );
@@ -169,7 +166,7 @@ public class ArtifactStoreFileSystemTest
     public void testSiteXmlSnapshotVersion() throws Exception
     {
         ArtifactStore store = mock( ArtifactStore.class );
-        when( store.get( isA( Artifact.class ) ) ).thenThrow( ArtifactNotFoundException.class );
+        when( store.getSize( isA( Artifact.class ) ) ).thenThrow( ArtifactNotFoundException.class );
         ArtifactStoreFileSystem system = new ArtifactStoreFileSystem( store );
         FileEntry entry = (FileEntry) system.get( "/localhost/mmockrm-5/1.0-SNAPSHOT/mmockrm-5-1.0-SNAPSHOT-site_en.xml" );
         assertNull( entry );


### PR DESCRIPTION
Method `ArtifactStore#get` was used for checking only if artifact exist
but return was not consumed and opened stream was never closed