### PR TITLE
Generate correct content of empty jars

### DIFF
--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/Utils.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/Utils.java
@@ -85,17 +85,14 @@ public final class Utils
     public static byte[] newEmptyJarContent()
         throws IOException
     {
-        byte[] emptyJar;
-        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-            final Manifest manifest = new Manifest();
-            manifest.getMainAttributes().putValue("Manifest-Version", "1.0");
-            manifest.getMainAttributes().putValue("Archiver-Version", "1.0");
-            manifest.getMainAttributes().putValue("Created-By", "Mock Repository Maven Plugin");
-            try (JarOutputStream jos = new JarOutputStream(bos, manifest)) {
-                emptyJar = bos.toByteArray();
-                return emptyJar;
-            }
-        }
+        final Manifest manifest = new Manifest();
+        manifest.getMainAttributes().putValue( "Manifest-Version", "1.0" );
+        manifest.getMainAttributes().putValue( "Archiver-Version", "1.0" );
+        manifest.getMainAttributes().putValue( "Created-By", "Mock Repository Maven Plugin" );
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        new JarOutputStream( bos, manifest ).close();
+        return bos.toByteArray();
     }
 
     /**
@@ -111,23 +108,23 @@ public final class Utils
     public static byte[] newEmptyMavenPluginJarContent( String groupId, String artifactId, String version )
         throws IOException
     {
-        byte[] emptyJar;
-        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-            final Manifest manifest = new Manifest();
-            manifest.getMainAttributes().putValue("Manifest-Version", "1.0");
-            manifest.getMainAttributes().putValue("Archiver-Version", "1.0");
-            manifest.getMainAttributes().putValue("Created-By", "Mock Repository Maven Plugin");
-            try (JarOutputStream jos = new JarOutputStream(bos, manifest)) {
-                JarEntry entry = new JarEntry("META-INF/maven/plugin.xml");
-                jos.putNextEntry(entry);
-                jos.write(
-                        ("<plugin><groupId>" + groupId + "</groupId><artifactId>" + artifactId + "</artifactId><version>" + version
-                                + "</version></plugin>").getBytes());
-                jos.closeEntry();
-                emptyJar = bos.toByteArray();
-                return emptyJar;
-            }
+        final Manifest manifest = new Manifest();
+        manifest.getMainAttributes().putValue( "Manifest-Version", "1.0" );
+        manifest.getMainAttributes().putValue( "Archiver-Version", "1.0" );
+        manifest.getMainAttributes().putValue( "Created-By", "Mock Repository Maven Plugin" );
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        try ( JarOutputStream jos = new JarOutputStream( bos, manifest ) )
+        {
+            JarEntry entry = new JarEntry( "META-INF/maven/plugin.xml" );
+            jos.putNextEntry( entry );
+            jos.write(
+                ( "<plugin><groupId>" + groupId + "</groupId><artifactId>" + artifactId + "</artifactId><version>"
+                    + version
+                    + "</version></plugin>" ).getBytes() );
+            jos.closeEntry();
         }
+        return bos.toByteArray();
     }
 
     /**

--- a/mrm-servlet/src/test/resources/empty-jar/mrm-empty-jar-1.0.pom
+++ b/mrm-servlet/src/test/resources/empty-jar/mrm-empty-jar-1.0.pom
@@ -1,0 +1,6 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>mrm-empty-jar</artifactId>
+  <version>1.0</version>
+</project>

--- a/mrm-servlet/src/test/resources/empty-plugin-jar/mrm-empty-plugin-jar-1.0.pom
+++ b/mrm-servlet/src/test/resources/empty-plugin-jar/mrm-empty-plugin-jar-1.0.pom
@@ -1,0 +1,7 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>mrm-empty-plugin-jar</artifactId>
+  <version>1.0</version>
+  <packaging>maven-plugin</packaging>
+</project>


### PR DESCRIPTION
- automatically generated empty jars had wrong content due to read output before stream close
- ByteArrayOutputStream needn't be closed
- add test for empty jar and empty plugin jar