### PR TITLE
Include `Last-Modified` header in the response

### DIFF
--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/servlet/FileSystemServlet.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/servlet/FileSystemServlet.java
@@ -25,6 +25,11 @@ import java.net.HttpURLConnection;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Date;
 
@@ -158,6 +163,10 @@ public class FileSystemServlet
                 resp.setContentLength( (int) size );
             }
             resp.setContentType( getServletContext().getMimeType( fileEntry.getName() ) );
+
+            LocalDateTime lastModifiedDate = LocalDateTime.ofEpochSecond( fileEntry.getLastModified() / 1000, (int)(fileEntry.getLastModified() % 1000), ZoneOffset.UTC );
+            String formattedLastModifiedDate = lastModifiedDate.atZone( ZoneId.of("UTC") ).format( DateTimeFormatter.RFC_1123_DATE_TIME );
+            resp.addHeader( "Last-Modified",  formattedLastModifiedDate);
 
             try (InputStream source = fileEntry.getInputStream())
             {


### PR DESCRIPTION
I'm authoring a library, [dependency-history-maven](https://github.com/corgibytes/dependency-history-maven) that can query HTTP Maven repositories to determine the release history for a particular package. That library is using the `Last-Modified` header value to determine when a file was released into the repository. I'm also working on an integration of this library into a Maven plugin that uses `mrm` for its integration tests, so I need `mrm` to include the `Last-Modified` header for those tests to work.