### PR TITLE
Disable Jetty debug in Maven verbose mode

### DIFF
--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/AbstractStartMojo.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/AbstractStartMojo.java
@@ -64,6 +64,16 @@ public abstract class AbstractStartMojo
     private ArtifactStoreFactory[] repositories;
 
     /**
+     * Indicate if Jetty server should produce logs in debug level.
+     * <p>
+     * <b>Notice:</b> It is taken into account only when Maven is started in verbose mode.
+     *
+     * @since 1.5.0
+     */
+    @Parameter( property = "mrm.debugServer", defaultValue = "false" )
+    private boolean debugServer;
+
+    /**
      * Creates a file system server from an artifact store.
      *
      * @param artifactStore the artifact store to serve.
@@ -75,11 +85,11 @@ public abstract class AbstractStartMojo
                                      Math.max( 0, Math.min( port, 65535 ) ),
                                      basePath,
                                      new AutoDigestFileSystem( new ArtifactStoreFileSystem( artifactStore ) ),
-                                     getSettingsServletPath() );
+                                     getSettingsServletPath(), debugServer );
     }
 
     /**
-     * When set, this points to the to the location from where the settings file can be downloaded.
+     * When set, this points to the location from where the settings file can be downloaded.
      *
      * @return the servlet path to the settings file of {@code null}
      */

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/ServerLogger.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/ServerLogger.java
@@ -1,0 +1,96 @@
+package org.codehaus.mojo.mrm.plugin;
+
+/*
+ * Copyright MojoHaus and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.log.Slf4jLog;
+
+/**
+ * Jetty SLF4J logger with debug level configuration.
+ *
+ * @author Slawomir Jaranowski
+ */
+class ServerLogger extends Slf4jLog
+{
+    private final boolean debugEnabled;
+
+    public ServerLogger( boolean debugEnabled )
+    {
+        this( ServerLogger.class.getName(), debugEnabled );
+    }
+
+    public ServerLogger( String name, boolean debugEnabled )
+    {
+        super( name );
+        this.debugEnabled = debugEnabled;
+    }
+
+    @Override
+    public void debug( String msg, Object... args )
+    {
+        if ( isDebugEnabled() )
+        {
+            super.debug( msg, args );
+        }
+    }
+
+    @Override
+    public void debug( String msg, long arg )
+    {
+        if ( isDebugEnabled() )
+        {
+            super.debug( msg, arg );
+        }
+    }
+
+    @Override
+    public void debug( Throwable thrown )
+    {
+        if ( isDebugEnabled() )
+        {
+            super.debug( thrown );
+        }
+    }
+
+    @Override
+    public void debug( String msg, Throwable thrown )
+    {
+        if ( isDebugEnabled() )
+        {
+            super.debug( msg, thrown );
+        }
+    }
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return debugEnabled;
+    }
+
+    @Override
+    public void setDebugEnabled( boolean enabled )
+    {
+        // do nothing
+    }
+
+    @Override
+    protected Logger newLogger( String fullname )
+    {
+        return new ServerLogger( fullname, debugEnabled );
+    }
+}


### PR DESCRIPTION
Jetty produces many debug logs, it can make mess in verbose mode. 

Disabled by default, can be enabled by debugServer parameter.