### PR TITLE
Resolves #99: Removing dependencies on maven-artifact-manager from Maven 2

### DIFF
--- a/mrm-maven-plugin/src/test/java/org/codehaus/mojo/mrm/maven/ProxyArtifactStoreTest.java
+++ b/mrm-maven-plugin/src/test/java/org/codehaus/mojo/mrm/maven/ProxyArtifactStoreTest.java
@@ -89,7 +89,7 @@ public class ProxyArtifactStoreTest {
     @Test(expected = RuntimeException.class)
     public void verifyArchetypeCatalogNotFoundException() throws Exception {
         ArchetypeManager archetypeManager = mock(ArchetypeManager.class);
-        doThrow(RuntimeException.class).when(archetypeManager).getDefaultLocalCatalog();
+        doThrow(RuntimeException.class).when(archetypeManager).getLocalCatalog(any());
         FactoryHelper factoryHelper = mock(FactoryHelper.class);
         when(factoryHelper.getRepositorySystem()).then(i -> mock(RepositorySystem.class));
         when(factoryHelper.getRepositoryMetadataManager()).then(i -> mock(RepositoryMetadataManager.class));

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
       <dependency>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-common</artifactId>
-        <version>2.2</version>
+        <version>3.2.1</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>


### PR DESCRIPTION
- Snapshot artifact metadata is no longer supported as separate artifact types as of Maven 3
- Ditto for Group artifact metadata
- Bumped archetype-common to 3.2.1
@slawekjaranowski  please review