### PR TITLE
Workaround for #179 - skip checksums for deployed metadata

### DIFF
--- a/mrm-maven-plugin/src/it/hostedrepo/src/it/deploy-release/verify.groovy
+++ b/mrm-maven-plugin/src/it/hostedrepo/src/it/deploy-release/verify.groovy
@@ -2,3 +2,6 @@ assert new File( basedir, '../../hosted-repo/org/mojohaus/mrm/hostedrepo/its/dep
 assert new File( basedir, '../../hosted-repo/org/mojohaus/mrm/hostedrepo/its/deploy/1.0.0/deploy-1.0.0.pom').exists()
 assert new File( basedir, '../../hosted-repo/org/mojohaus/mrm/hostedrepo/its/deploy/1.0.0/deploy-1.0.0.pom.md5').exists()
 assert new File( basedir, '../../hosted-repo/org/mojohaus/mrm/hostedrepo/its/deploy/1.0.0/deploy-1.0.0.pom.sha1').exists()
+
+def logs = new File( basedir, 'build.log').text;
+assert !logs.contains('[WARNING] Failed to upload checksum')

--- a/mrm-maven-plugin/src/it/hostedrepo/src/it/deploy-snapshot/verify.groovy
+++ b/mrm-maven-plugin/src/it/hostedrepo/src/it/deploy-snapshot/verify.groovy
@@ -8,3 +8,6 @@ assert path != null : "Could not locate pom based on regular expression"
 assert new File(path).exists()
 assert new File(path + '.md5').exists()
 assert new File(path + '.sha1').exists()
+
+def logs = new File( basedir, 'build.log').text;
+assert !logs.contains('[WARNING] Failed to upload checksum')

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/ArtifactStoreFileSystem.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/ArtifactStoreFileSystem.java
@@ -345,6 +345,14 @@ public class ArtifactStoreFileSystem extends BaseFileSystem {
             return new MetadataFileEntry(this, parent, path, store);
         }
 
+        if (name.startsWith("maven-metadata.xml") && (name.endsWith(".sha1") || name.endsWith(".md5"))) {
+            // checksum for metadata ... ignore now
+            // return something != null
+            // TODO add support for storing checksum files
+            // https://github.com/mojohaus/mrm/issues/179
+            return new MetadataFileEntry(this, parent, path, store);
+        }
+
         Artifact artifact = getArtifact(parent, name);
 
         if (artifact == null) {


### PR DESCRIPTION
We can now skip checksum for metadata to avoid generating warning
Proper way needs more code refactor