### PR TITLE
Get rid of usage RepositoryMetadataManager

### DIFF
--- a/mrm-api/src/main/java/org/codehaus/mojo/mrm/plugin/FactoryHelper.java
+++ b/mrm-api/src/main/java/org/codehaus/mojo/mrm/plugin/FactoryHelper.java
@@ -17,7 +17,6 @@
 package org.codehaus.mojo.mrm.plugin;
 
 import org.apache.maven.archetype.ArchetypeManager;
-import org.apache.maven.artifact.repository.metadata.RepositoryMetadataManager;
 import org.eclipse.aether.RepositorySystem;
 
 /**
@@ -30,12 +29,6 @@ public interface FactoryHelper {
      * @return returns the {@link RepositorySystem} instance
      */
     RepositorySystem getRepositorySystem();
-
-    /**
-     * @return returns the {@link RepositoryMetadataManager} instance
-     * @since 1.0
-     */
-    RepositoryMetadataManager getRepositoryMetadataManager();
 
     /**
      * @return returns the {@link ArchetypeManager} instance

--- a/mrm-maven-plugin/pom.xml
+++ b/mrm-maven-plugin/pom.xml
@@ -120,6 +120,10 @@
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
+    </dependency>
 
     <!-- tests -->
     <dependency>

--- a/mrm-maven-plugin/src/it/hostedrepo/src/it/plugins-metadata/invoker.properties
+++ b/mrm-maven-plugin/src/it/hostedrepo/src/it/plugins-metadata/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = help:system

--- a/mrm-maven-plugin/src/it/hostedrepo/src/it/plugins-metadata/pom.xml
+++ b/mrm-maven-plugin/src/it/hostedrepo/src/it/plugins-metadata/pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>org.mojohaus.mrm.hostedrepo.its</groupId>
+  <artifactId>plugins-metadata</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+
+  <description>Test if plugins metadata G level is downloaded</description>
+</project>

--- a/mrm-maven-plugin/src/it/hostedrepo/src/it/settings.xml
+++ b/mrm-maven-plugin/src/it/hostedrepo/src/it/settings.xml
@@ -34,7 +34,7 @@ under the License.
       <repositories>
         <repository>
           <id>local.central</id>
-          <url>http://local.central</url>
+          <url>http://localhost</url>
           <releases>
             <enabled>true</enabled>
           </releases>
@@ -46,7 +46,7 @@ under the License.
       <pluginRepositories>
         <pluginRepository>
           <id>local.central</id>
-          <url>http://local.central</url>
+          <url>http://localhost</url>
           <releases>
             <enabled>true</enabled>
           </releases>

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/DefaultFactoryHelper.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/DefaultFactoryHelper.java
@@ -5,7 +5,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.maven.archetype.ArchetypeManager;
-import org.apache.maven.artifact.repository.metadata.RepositoryMetadataManager;
 import org.eclipse.aether.RepositorySystem;
 
 /**
@@ -18,28 +17,17 @@ import org.eclipse.aether.RepositorySystem;
 public class DefaultFactoryHelper implements FactoryHelper {
     private RepositorySystem repositorySystem;
 
-    private RepositoryMetadataManager repositoryMetadataManager;
-
     private ArchetypeManager archetypeManager;
 
     @Inject
-    public DefaultFactoryHelper(
-            RepositorySystem repositorySystem,
-            RepositoryMetadataManager repositoryMetadataManager,
-            ArchetypeManager archetypeManager) {
+    public DefaultFactoryHelper(RepositorySystem repositorySystem, ArchetypeManager archetypeManager) {
         this.repositorySystem = repositorySystem;
-        this.repositoryMetadataManager = repositoryMetadataManager;
         this.archetypeManager = archetypeManager;
     }
 
     @Override
     public RepositorySystem getRepositorySystem() {
         return repositorySystem;
-    }
-
-    @Override
-    public RepositoryMetadataManager getRepositoryMetadataManager() {
-        return repositoryMetadataManager;
     }
 
     @Override

--- a/mrm-maven-plugin/src/test/java/org/codehaus/mojo/mrm/maven/ProxyArtifactStoreTest.java
+++ b/mrm-maven-plugin/src/test/java/org/codehaus/mojo/mrm/maven/ProxyArtifactStoreTest.java
@@ -22,7 +22,6 @@ package org.codehaus.mojo.mrm.maven;
 import java.util.Collections;
 
 import org.apache.maven.archetype.ArchetypeManager;
-import org.apache.maven.artifact.repository.metadata.RepositoryMetadataManager;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.mojo.mrm.api.maven.Artifact;
@@ -63,7 +62,6 @@ class ProxyArtifactStoreTest {
         doThrow(ArtifactResolutionException.class).when(repositorySystem).resolveArtifact(any(), any());
         FactoryHelper factoryHelper = mock(FactoryHelper.class);
         when(factoryHelper.getRepositorySystem()).thenReturn(repositorySystem);
-        when(factoryHelper.getRepositoryMetadataManager()).then(i -> mock(RepositoryMetadataManager.class));
         when(factoryHelper.getArchetypeManager()).then(i -> mock(ArchetypeManager.class));
 
         ProxyArtifactStore store = new ProxyArtifactStore(factoryHelper, mavenSession, null);
@@ -79,7 +77,6 @@ class ProxyArtifactStoreTest {
         doThrow(new RuntimeException("test123")).when(repositorySystem).resolveArtifact(any(), any());
         FactoryHelper factoryHelper = mock(FactoryHelper.class);
         when(factoryHelper.getRepositorySystem()).thenReturn(repositorySystem);
-        when(factoryHelper.getRepositoryMetadataManager()).then(i -> mock(RepositoryMetadataManager.class));
         when(factoryHelper.getArchetypeManager()).then(i -> mock(ArchetypeManager.class));
 
         ProxyArtifactStore store = new ProxyArtifactStore(factoryHelper, mavenSession, null);
@@ -95,7 +92,6 @@ class ProxyArtifactStoreTest {
         doThrow(new RuntimeException("test123")).when(archetypeManager).getLocalCatalog(any());
         FactoryHelper factoryHelper = mock(FactoryHelper.class);
         when(factoryHelper.getRepositorySystem()).then(i -> mock(RepositorySystem.class));
-        when(factoryHelper.getRepositoryMetadataManager()).then(i -> mock(RepositoryMetadataManager.class));
         when(factoryHelper.getArchetypeManager()).thenReturn(archetypeManager);
         ProxyArtifactStore store = new ProxyArtifactStore(factoryHelper, mavenSession, null);
 


### PR DESCRIPTION
`RepositoryMetadataManager` is deprecated - has only implementation in `maven-compat`

We should use repositorySystem.resolveMetadata