### PR TITLE
Refactor classes used as repository configurations

### DIFF
--- a/mrm-api/src/main/java/org/codehaus/mojo/mrm/plugin/ArtifactStoreFactory.java
+++ b/mrm-api/src/main/java/org/codehaus/mojo/mrm/plugin/ArtifactStoreFactory.java
@@ -16,8 +16,6 @@
 
 package org.codehaus.mojo.mrm.plugin;
 
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.logging.Log;
 import org.codehaus.mojo.mrm.api.maven.ArtifactStore;
 
 /**
@@ -30,18 +28,15 @@ public interface ArtifactStoreFactory {
      * Creates a new {@link ArtifactStore} instance, note that implementations are free to create a singleton and always
      * return that instance.
      *
-     * @param session {@link MavenSession} instance
-     * @param log {@link Log} instance
-     *
+     * @param factoryHelper {@link FactoryHelper} instance
      * @return the {@link ArtifactStore} instance.
      * @since 1.0
      */
-    ArtifactStore newInstance(MavenSession session, Log log);
+    default ArtifactStore newInstance(FactoryHelper factoryHelper) {
+        return newInstance();
+    }
 
-    /**
-     * Sets the {@link FactoryHelper} instance where the object is not injected by dependency injection
-     *
-     * @param factoryHelper {@link FactoryHelper} instance
-     */
-    void setFactoryHelper(FactoryHelper factoryHelper);
+    default ArtifactStore newInstance() {
+        throw new UnsupportedOperationException("method newInstance() not implemented");
+    }
 }

--- a/mrm-api/src/main/java/org/codehaus/mojo/mrm/plugin/FactoryHelper.java
+++ b/mrm-api/src/main/java/org/codehaus/mojo/mrm/plugin/FactoryHelper.java
@@ -17,6 +17,7 @@
 package org.codehaus.mojo.mrm.plugin;
 
 import org.apache.maven.archetype.ArchetypeManager;
+import org.apache.maven.execution.MavenSession;
 import org.eclipse.aether.RepositorySystem;
 
 /**
@@ -35,4 +36,9 @@ public interface FactoryHelper {
      * @since 1.0
      */
     ArchetypeManager getArchetypeManager();
+
+    /**
+     * @return returns the current {@link MavenSession} instance
+     */
+    MavenSession getMavenSession();
 }

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/AbstractMRMMojo.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/AbstractMRMMojo.java
@@ -24,7 +24,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.mojo.mrm.maven.ProxyArtifactStore;
 
 /**
  * Base class for all the Mock Repository Manager's Mojos.
@@ -32,8 +31,6 @@ import org.codehaus.mojo.mrm.maven.ProxyArtifactStore;
  * @since 1.0
  */
 public abstract class AbstractMRMMojo extends AbstractMojo {
-    protected final ArtifactStoreFactory proxyRepo;
-
     /**
      * The Maven project.
      */
@@ -65,14 +62,6 @@ public abstract class AbstractMRMMojo extends AbstractMojo {
     protected boolean skip;
 
     /**
-     * Creates a new instance
-     * @param proxyRepo injected proxyRepo
-     */
-    protected AbstractMRMMojo(ArtifactStoreFactory proxyRepo) {
-        this.proxyRepo = proxyRepo;
-    }
-
-    /**
      * Executes the plugin goal (if the plugin is not skipped)
      *
      * @throws MojoExecutionException If there is an exception occuring during the execution of the plugin.
@@ -102,15 +91,4 @@ public abstract class AbstractMRMMojo extends AbstractMojo {
      * @throws MojoFailureException If there is an exception occuring during the execution of the plugin.
      */
     protected abstract void doExecute() throws MojoExecutionException, MojoFailureException;
-
-    /**
-     * Creates an {@link org.codehaus.mojo.mrm.api.maven.ArtifactStore} that fetches from the repositories available to
-     * Maven itself.
-     *
-     * @return an {@link org.codehaus.mojo.mrm.api.maven.ArtifactStore} that fetches from the repositories available to
-     *         Maven itself.
-     */
-    protected ProxyArtifactStore createProxyArtifactStore() {
-        return (ProxyArtifactStore) proxyRepo.newInstance(session, getLog());
-    }
 }

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/DefaultFactoryHelper.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/DefaultFactoryHelper.java
@@ -2,9 +2,11 @@ package org.codehaus.mojo.mrm.plugin;
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.apache.maven.archetype.ArchetypeManager;
+import org.apache.maven.execution.MavenSession;
 import org.eclipse.aether.RepositorySystem;
 
 /**
@@ -19,10 +21,16 @@ public class DefaultFactoryHelper implements FactoryHelper {
 
     private ArchetypeManager archetypeManager;
 
+    private final Provider<MavenSession> mavenSessionProvider;
+
     @Inject
-    public DefaultFactoryHelper(RepositorySystem repositorySystem, ArchetypeManager archetypeManager) {
+    public DefaultFactoryHelper(
+            RepositorySystem repositorySystem,
+            ArchetypeManager archetypeManager,
+            Provider<MavenSession> mavenSessionProvider) {
         this.repositorySystem = repositorySystem;
         this.archetypeManager = archetypeManager;
+        this.mavenSessionProvider = mavenSessionProvider;
     }
 
     @Override
@@ -33,5 +41,10 @@ public class DefaultFactoryHelper implements FactoryHelper {
     @Override
     public ArchetypeManager getArchetypeManager() {
         return archetypeManager;
+    }
+
+    @Override
+    public MavenSession getMavenSession() {
+        return mavenSessionProvider.get();
     }
 }

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/ProxyRepo.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/ProxyRepo.java
@@ -16,14 +16,8 @@ package org.codehaus.mojo.mrm.plugin;
  * limitations under the License.
  */
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import java.util.Objects;
 
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.logging.Log;
 import org.codehaus.mojo.mrm.api.maven.ArtifactStore;
 import org.codehaus.mojo.mrm.maven.ProxyArtifactStore;
 
@@ -32,37 +26,11 @@ import org.codehaus.mojo.mrm.maven.ProxyArtifactStore;
  *
  * @since 1.0
  */
-@Named("proxyRepo")
-@Singleton
 public class ProxyRepo implements ArtifactStoreFactory {
 
-    private FactoryHelper factoryHelper;
-
-    /**
-     * Constructor used by Plexus configuration injector.
-     * Note: since it does not provide the {@link FactoryHelper} instance, the instance needs
-     * to be provided using {@link #setFactoryHelper(FactoryHelper)}
-     */
-    public ProxyRepo() {}
-
-    /**
-     * Injects the singleton instance
-     * @param factoryHelper injected {@link FactoryHelper} instance
-     */
-    @Inject
-    public ProxyRepo(FactoryHelper factoryHelper) {
-        this.factoryHelper = factoryHelper;
-    }
-
     @Override
-    public ArtifactStore newInstance(MavenSession session, Log log) {
-        return new ProxyArtifactStore(
-                Objects.requireNonNull(factoryHelper, "FactoryHelper has not been set"), session, log);
-    }
-
-    @Override
-    public void setFactoryHelper(FactoryHelper factoryHelper) {
-        this.factoryHelper = factoryHelper;
+    public ArtifactStore newInstance(FactoryHelper factoryHelper) {
+        return new ProxyArtifactStore(Objects.requireNonNull(factoryHelper, "FactoryHelper has not been set"));
     }
 
     @Override

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/RunMojo.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/RunMojo.java
@@ -17,7 +17,6 @@ package org.codehaus.mojo.mrm.plugin;
  */
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -37,11 +36,10 @@ public class RunMojo extends AbstractStartMojo {
     /**
      * Creates a new instance
      * @param factoryHelper injected {@link FactoryHelper} instance
-     * @param proxyRepo injected proxyRepo
      */
     @Inject
-    public RunMojo(FactoryHelper factoryHelper, @Named("proxyRepo") ArtifactStoreFactory proxyRepo) {
-        super(factoryHelper, proxyRepo);
+    public RunMojo(FactoryHelper factoryHelper) {
+        super(factoryHelper);
     }
 
     @Override

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/StartMojo.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/StartMojo.java
@@ -17,7 +17,6 @@ package org.codehaus.mojo.mrm.plugin;
  */
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
 import java.util.Map;
 
@@ -46,8 +45,8 @@ public class StartMojo extends AbstractStartMojo {
     private String propertyName;
 
     @Inject
-    public StartMojo(FactoryHelper factoryHelper, @Named("proxyRepo") ArtifactStoreFactory proxyRepo) {
-        super(factoryHelper, proxyRepo);
+    public StartMojo(FactoryHelper factoryHelper) {
+        super(factoryHelper);
     }
 
     @Override

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/StopMojo.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/StopMojo.java
@@ -16,9 +16,6 @@ package org.codehaus.mojo.mrm.plugin;
  * limitations under the License.
  */
 
-import javax.inject.Inject;
-import javax.inject.Named;
-
 import java.util.Map;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -37,11 +34,6 @@ import org.apache.maven.plugins.annotations.Mojo;
  */
 @Mojo(name = "stop", defaultPhase = LifecyclePhase.POST_INTEGRATION_TEST, requiresProject = false, threadSafe = true)
 public class StopMojo extends AbstractMRMMojo {
-
-    @Inject
-    public StopMojo(@Named("proxyRepo") ArtifactStoreFactory proxyRepo) {
-        super(proxyRepo);
-    }
 
     @Override
     public void doExecute() throws MojoExecutionException, MojoFailureException {

--- a/mrm-maven-plugin/src/test/java/org/codehaus/mojo/mrm/maven/ProxyArtifactStoreTest.java
+++ b/mrm-maven-plugin/src/test/java/org/codehaus/mojo/mrm/maven/ProxyArtifactStoreTest.java
@@ -63,8 +63,9 @@ class ProxyArtifactStoreTest {
         FactoryHelper factoryHelper = mock(FactoryHelper.class);
         when(factoryHelper.getRepositorySystem()).thenReturn(repositorySystem);
         when(factoryHelper.getArchetypeManager()).then(i -> mock(ArchetypeManager.class));
+        when(factoryHelper.getMavenSession()).thenReturn(mavenSession);
 
-        ProxyArtifactStore store = new ProxyArtifactStore(factoryHelper, mavenSession, null);
+        ProxyArtifactStore store = new ProxyArtifactStore(factoryHelper);
 
         assertThrowsExactly(
                 ArtifactNotFoundException.class,
@@ -78,8 +79,9 @@ class ProxyArtifactStoreTest {
         FactoryHelper factoryHelper = mock(FactoryHelper.class);
         when(factoryHelper.getRepositorySystem()).thenReturn(repositorySystem);
         when(factoryHelper.getArchetypeManager()).then(i -> mock(ArchetypeManager.class));
+        when(factoryHelper.getMavenSession()).thenReturn(mavenSession);
 
-        ProxyArtifactStore store = new ProxyArtifactStore(factoryHelper, mavenSession, null);
+        ProxyArtifactStore store = new ProxyArtifactStore(factoryHelper);
 
         RuntimeException exception = assertThrowsExactly(
                 RuntimeException.class, () -> store.get(new Artifact("localhost", "test", "1.0-SNAPSHOT", "pom")));
@@ -87,13 +89,14 @@ class ProxyArtifactStoreTest {
     }
 
     @Test
-    void verifyArchetypeCatalogNotFoundException() throws Exception {
+    void verifyArchetypeCatalogNotFoundException() {
         ArchetypeManager archetypeManager = mock(ArchetypeManager.class);
         doThrow(new RuntimeException("test123")).when(archetypeManager).getLocalCatalog(any());
         FactoryHelper factoryHelper = mock(FactoryHelper.class);
         when(factoryHelper.getRepositorySystem()).then(i -> mock(RepositorySystem.class));
         when(factoryHelper.getArchetypeManager()).thenReturn(archetypeManager);
-        ProxyArtifactStore store = new ProxyArtifactStore(factoryHelper, mavenSession, null);
+        when(factoryHelper.getMavenSession()).thenReturn(mavenSession);
+        ProxyArtifactStore store = new ProxyArtifactStore(factoryHelper);
 
         RuntimeException exception = assertThrowsExactly(RuntimeException.class, store::getArchetypeCatalog);
         assertEquals("test123", exception.getMessage());

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStore.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStore.java
@@ -53,7 +53,6 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
-import org.apache.maven.plugin.logging.Log;
 import org.codehaus.mojo.mrm.api.maven.ArchetypeCatalogNotFoundException;
 import org.codehaus.mojo.mrm.api.maven.Artifact;
 import org.codehaus.mojo.mrm.api.maven.ArtifactNotFoundException;
@@ -65,6 +64,8 @@ import org.codehaus.plexus.archiver.jar.JarArchiver;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An artifact store that keeps all its artifacts in memory.
@@ -73,7 +74,7 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
  */
 public class MockArtifactStore extends BaseArtifactStore {
 
-    private final Log log;
+    private static final Logger LOGGER = LoggerFactory.getLogger(MockArtifactStore.class);
 
     private final boolean lazyArchiver;
 
@@ -100,29 +101,16 @@ public class MockArtifactStore extends BaseArtifactStore {
      * @since 1.0
      */
     public MockArtifactStore(File root) {
-        this(null, root);
+        this(root, true);
     }
 
     /**
      * Create a mock artifact store by scanning for POMs within the specified root.
      *
      * @param root the root to search for POMs within.
-     * @param log  the {@link Log} to log to.
      * @since 1.0
      */
-    public MockArtifactStore(Log log, File root) {
-        this(log, root, true);
-    }
-
-    /**
-     * Create a mock artifact store by scanning for POMs within the specified root.
-     *
-     * @param root the root to search for POMs within.
-     * @param log  the {@link Log} to log to.
-     * @since 1.0
-     */
-    public MockArtifactStore(Log log, File root, boolean lazyArchiver) {
-        this.log = log;
+    public MockArtifactStore(File root, boolean lazyArchiver) {
         this.lazyArchiver = lazyArchiver;
 
         if (root.isDirectory()) {
@@ -178,12 +166,12 @@ public class MockArtifactStore extends BaseArtifactStore {
                         set(new Artifact(groupId, model.getArtifactId(), version, classifier, type), content);
                     }
                 } catch (IOException e) {
-                    if (log != null) {
-                        log.warn("Could not read from " + file, e);
+                    if (LOGGER != null) {
+                        LOGGER.warn("Could not read from " + file, e);
                     }
                 } catch (XmlPullParserException e) {
-                    if (log != null) {
-                        log.warn("Could not parse " + file, e);
+                    if (LOGGER != null) {
+                        LOGGER.warn("Could not parse " + file, e);
                     }
                 }
             }
@@ -570,13 +558,13 @@ public class MockArtifactStore extends BaseArtifactStore {
             try {
                 return reader.read(archetypeCatalog.getInputStream());
             } catch (IOException e) {
-                if (log != null) {
-                    log.warn("Could not read from archetype-catalog.xml", e);
+                if (LOGGER != null) {
+                    LOGGER.warn("Could not read from archetype-catalog.xml", e);
                 }
             } catch (XmlPullParserException e) {
 
-                if (log != null) {
-                    log.warn("Could not parse archetype-catalog.xml", e);
+                if (LOGGER != null) {
+                    LOGGER.warn("Could not parse archetype-catalog.xml", e);
                 }
             }
         }

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/plugin/HostedRepo.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/plugin/HostedRepo.java
@@ -1,12 +1,7 @@
 package org.codehaus.mojo.mrm.plugin;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import java.io.File;
 
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.logging.Log;
 import org.codehaus.mojo.mrm.api.maven.ArtifactStore;
 import org.codehaus.mojo.mrm.impl.maven.DiskArtifactStore;
 
@@ -16,8 +11,6 @@ import org.codehaus.mojo.mrm.impl.maven.DiskArtifactStore;
  * @author Robert Scholte
  * @since 1.1.0
  */
-@Named("hostedRepo")
-@Singleton
 public class HostedRepo implements ArtifactStoreFactory {
     /**
      * The directory to store the uploaded files
@@ -25,15 +18,12 @@ public class HostedRepo implements ArtifactStoreFactory {
     private File target;
 
     @Override
-    public ArtifactStore newInstance(MavenSession session, Log log) {
+    public ArtifactStore newInstance() {
         if (target == null) {
             throw new IllegalStateException("Must provide the 'target' of the hosted repository");
         }
         return new DiskArtifactStore(target).canWrite(true);
     }
-
-    @Override
-    public void setFactoryHelper(FactoryHelper ignored) {}
 
     @Override
     public String toString() {

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/plugin/LocalRepo.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/plugin/LocalRepo.java
@@ -1,12 +1,7 @@
 package org.codehaus.mojo.mrm.plugin;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import java.io.File;
 
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.logging.Log;
 import org.codehaus.mojo.mrm.api.maven.ArtifactStore;
 import org.codehaus.mojo.mrm.impl.maven.DiskArtifactStore;
 
@@ -15,8 +10,6 @@ import org.codehaus.mojo.mrm.impl.maven.DiskArtifactStore;
  *
  * @since 1.0
  */
-@Named("localRepo")
-@Singleton
 public class LocalRepo implements ArtifactStoreFactory {
 
     /**
@@ -27,15 +20,12 @@ public class LocalRepo implements ArtifactStoreFactory {
     private File source;
 
     @Override
-    public ArtifactStore newInstance(MavenSession session, Log log) {
+    public ArtifactStore newInstance() {
         if (source == null) {
             throw new IllegalStateException("Must provide the 'source' of the local repository");
         }
         return new DiskArtifactStore(source);
     }
-
-    @Override
-    public void setFactoryHelper(FactoryHelper ignored) {}
 
     /**
      * {@inheritDoc}

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/plugin/MockRepo.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/plugin/MockRepo.java
@@ -1,16 +1,9 @@
 package org.codehaus.mojo.mrm.plugin;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import java.io.File;
 import java.io.IOException;
-import java.util.Objects;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.logging.Log;
 import org.codehaus.mojo.mrm.api.maven.ArtifactStore;
 import org.codehaus.mojo.mrm.impl.maven.MockArtifactStore;
 
@@ -19,12 +12,7 @@ import org.codehaus.mojo.mrm.impl.maven.MockArtifactStore;
  *
  * @since 1.0
  */
-@Named("mockRepo")
-@Singleton
 public class MockRepo implements ArtifactStoreFactory {
-
-    @Inject
-    private FactoryHelper factoryHelper;
 
     /**
      * Our source.
@@ -56,9 +44,7 @@ public class MockRepo implements ArtifactStoreFactory {
     private boolean lazyArchiver;
 
     @Override
-    public ArtifactStore newInstance(MavenSession session, Log log) {
-        Objects.requireNonNull(factoryHelper, "FactoryHelper has not been set");
-
+    public ArtifactStore newInstance() {
         if (source == null) {
             throw new IllegalStateException("Must provide the 'source' of the mock repository");
         }
@@ -81,12 +67,7 @@ public class MockRepo implements ArtifactStoreFactory {
             }
         }
 
-        return new MockArtifactStore(log, root, lazyArchiver);
-    }
-
-    @Override
-    public void setFactoryHelper(FactoryHelper factoryHelper) {
-        this.factoryHelper = factoryHelper;
+        return new MockArtifactStore(root, lazyArchiver);
     }
 
     /**


### PR DESCRIPTION
- classes used as repository configurations are not a beans
- use FactoryHelper as argument in ArtifactStoreFactory.newInstance instead as class field
- move MavenSession from method argument in ArtifactStoreFactory.newInstance to FactoryHelper