### PR TITLE
Add x-checksum-sha1 http header for mocked repositories

### DIFF
--- a/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/BaseFileEntry.java
+++ b/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/BaseFileEntry.java
@@ -16,6 +16,8 @@
 
 package org.codehaus.mojo.mrm.api;
 
+import java.io.IOException;
+
 /**
  * Base implementation of {@link FileEntry} that all implementations should extend from.
  *
@@ -33,5 +35,10 @@ public abstract class BaseFileEntry extends AbstractEntry implements FileEntry {
      */
     protected BaseFileEntry(FileSystem fileSystem, DirectoryEntry parent, String name) {
         super(fileSystem, parent, name);
+    }
+
+    @Override
+    public String getSha1Checksum() throws IOException {
+        return null;
     }
 }

--- a/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/FileEntry.java
+++ b/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/FileEntry.java
@@ -42,4 +42,13 @@ public interface FileEntry extends Entry {
      * @since 1.0
      */
     InputStream getInputStream() throws IOException;
+
+    /**
+     * Returns the SHA-1 checksum of the entry.
+     *
+     * @return the SHA-1 checksum of the entry as a hex string, or <code>null</code> if the checksum cannot be computed.
+     * @throws IOException if an I/O error occurs.
+     * @since 1.7.0
+     */
+    String getSha1Checksum() throws IOException;
 }

--- a/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/maven/ArtifactStore.java
+++ b/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/maven/ArtifactStore.java
@@ -163,6 +163,17 @@ public interface ArtifactStore {
     void set(Artifact artifact, InputStream content) throws IOException;
 
     /**
+     * Returns the SHA-1 checksum of the artifact.
+     *
+     * @param artifact the artifact
+     * @return the SHA-1 checksum of the entry as a hex string, or <code>null</code> if the checksum cannot be computed.
+     * @throws IOException               if the artifact could not be retrieved.
+     * @throws ArtifactNotFoundException if the artifact does not exist.
+     * @since 1.7.0
+     */
+    String getSha1Checksum(Artifact artifact) throws IOException, ArtifactNotFoundException;
+
+    /**
      * Returns the specified metadata.
      *
      * @param path of the metadata (should not include the <code>maven-metadata.xml</code>.

--- a/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/maven/BaseArtifactStore.java
+++ b/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/maven/BaseArtifactStore.java
@@ -14,13 +14,6 @@ import org.apache.maven.artifact.repository.metadata.Metadata;
  */
 public abstract class BaseArtifactStore implements ArtifactStore {
 
-    /**
-     * Ensure consistent serialization.
-     *
-     * @since 1.0
-     */
-    private static final long serialVersionUID = 1L;
-
     @Override
     public void set(Artifact artifact, InputStream content) throws IOException {
         throw new UnsupportedOperationException("Read-only artifact store");

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/maven/ProxyArtifactStore.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/maven/ProxyArtifactStore.java
@@ -19,6 +19,7 @@ package org.codehaus.mojo.mrm.maven;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -214,6 +215,16 @@ public class ProxyArtifactStore extends BaseArtifactStore {
     @Override
     public InputStream get(Artifact artifact) throws IOException, ArtifactNotFoundException {
         return Files.newInputStream(resolveArtifactFile(artifact).toPath());
+    }
+
+    @Override
+    public String getSha1Checksum(Artifact artifact) throws IOException, ArtifactNotFoundException {
+        File sha1File = new File(resolveArtifactFile(artifact).getPath() + ".sha1");
+        if (sha1File.isFile()) {
+            return new String(Files.readAllBytes(sha1File.toPath()), StandardCharsets.US_ASCII);
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/mrm-servlet/pom.xml
+++ b/mrm-servlet/pom.xml
@@ -63,6 +63,10 @@
 
     <!-- commons -->
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
@@ -96,6 +100,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/LinkFileEntry.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/LinkFileEntry.java
@@ -80,4 +80,9 @@ public class LinkFileEntry extends BaseFileEntry {
     public InputStream getInputStream() throws IOException {
         return entry.getInputStream();
     }
+
+    @Override
+    public String getSha1Checksum() throws IOException {
+        return entry.getSha1Checksum();
+    }
 }

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/ArtifactFileEntry.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/ArtifactFileEntry.java
@@ -90,4 +90,13 @@ public class ArtifactFileEntry extends BaseFileEntry {
             throw new IOException("Artifact does not exist", e);
         }
     }
+
+    @Override
+    public String getSha1Checksum() throws IOException {
+        try {
+            return store.getSha1Checksum(artifact);
+        } catch (ArtifactNotFoundException e) {
+            throw new IOException("Artifact does not exist", e);
+        }
+    }
 }

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/CompositeArtifactStore.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/CompositeArtifactStore.java
@@ -140,6 +140,18 @@ public class CompositeArtifactStore extends BaseArtifactStore {
     }
 
     @Override
+    public String getSha1Checksum(Artifact artifact) throws IOException, ArtifactNotFoundException {
+        for (ArtifactStore store : stores) {
+            try {
+                return store.getSha1Checksum(artifact);
+            } catch (ArtifactNotFoundException e) {
+                // ignore
+            }
+        }
+        throw new ArtifactNotFoundException(artifact);
+    }
+
+    @Override
     public void set(Artifact artifact, InputStream content) throws IOException {
         throw new IOException("Read-only store");
     }

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/servlet/FileSystemServlet.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/servlet/FileSystemServlet.java
@@ -28,6 +28,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -85,6 +86,9 @@ public class FileSystemServlet extends HttpServlet {
             String formattedLastModifiedDate =
                     lastModifiedDate.atZone(ZoneId.of("UTC")).format(DateTimeFormatter.RFC_1123_DATE_TIME);
             resp.addHeader("Last-Modified", formattedLastModifiedDate);
+
+            Optional.ofNullable(fileEntry.getSha1Checksum())
+                    .ifPresent(sha1Checksum -> resp.addHeader("x-checksum-sha1", sha1Checksum));
 
             try (InputStream source = fileEntry.getInputStream()) {
                 IOUtils.copy(source, resp.getOutputStream());

--- a/mrm-servlet/src/test/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStoreTest.java
+++ b/mrm-servlet/src/test/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStoreTest.java
@@ -383,6 +383,22 @@ class MockArtifactStoreTest extends AbstractTestSupport {
     }
 
     @Test
+    void testSha1Checksum() throws Exception {
+        MockArtifactStore artifactStore = new MockArtifactStore(archiverManager, getResourceAsFile("/mrm-15"));
+
+        Artifact pomArtifact = new Artifact("localhost", "mrm-15", "1.0", "pom");
+        assertNotNull(artifactStore.getSha1Checksum(pomArtifact));
+
+        Artifact mainArtifact = new Artifact("localhost", "mrm-15", "1.0", "jar");
+        String sha1Jar1 = artifactStore.getSha1Checksum(mainArtifact);
+
+        artifactStore = new MockArtifactStore(archiverManager, getResourceAsFile("/mrm-15"));
+        String sha1Jar2 = artifactStore.getSha1Checksum(mainArtifact);
+
+        assertEquals(sha1Jar1, sha1Jar2);
+    }
+
+    @Test
     void groupMetaDataShouldNotExistForNoPlugins() throws Exception {
         MockArtifactStore artifactStore = new MockArtifactStore(archiverManager, getResourceAsFile("/empty-jar"));
 

--- a/mrm-servlet/src/test/java/org/codehaus/mojo/mrm/servlet/FileSystemServletTest.java
+++ b/mrm-servlet/src/test/java/org/codehaus/mojo/mrm/servlet/FileSystemServletTest.java
@@ -1,0 +1,77 @@
+package org.codehaus.mojo.mrm.servlet;
+
+import javax.servlet.ServletConfig;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.io.input.NullInputStream;
+import org.codehaus.mojo.mrm.api.maven.ArtifactStore;
+import org.codehaus.mojo.mrm.impl.maven.ArtifactStoreFileSystem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class FileSystemServletTest {
+
+    @Mock
+    private ArtifactStore store;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private ServletConfig servletConfig;
+
+    @Mock
+    private ServletContext servletContext;
+
+    @Mock
+    private ServletOutputStream servletOutputStream;
+
+    private FileSystemServlet servlet;
+
+    @BeforeEach
+    void setup() throws Exception {
+        when(servletConfig.getServletContext()).thenReturn(servletContext);
+
+        when(request.getPathInfo()).thenReturn("/commons/commons/1.0/commons-1.0.pom");
+        when(response.getOutputStream()).thenReturn(servletOutputStream);
+
+        when(store.get(any())).thenReturn(new NullInputStream());
+
+        servlet = new FileSystemServlet(new ArtifactStoreFileSystem(store));
+        servlet.init(servletConfig);
+    }
+
+    @Test
+    void xChecksumHeaderShouldBeAdded() throws Exception {
+        when(store.getSha1Checksum(any())).thenReturn("1234567890abcdef1234567890abcdef12345678");
+
+        servlet.doGet(request, response);
+
+        verify(response).addHeader("x-checksum-sha1", "1234567890abcdef1234567890abcdef12345678");
+    }
+
+    @Test
+    void xChecksumHeaderShouldBeNotAdded() throws Exception {
+        when(store.getSha1Checksum(any())).thenReturn(null);
+
+        servlet.doGet(request, response);
+
+        verify(response, never()).addHeader(eq("x-checksum-sha1"), any());
+    }
+}

--- a/mrm-servlet/src/test/resources/local-repo-unit/org/group1/artifact1/2.0.0/artifact1-2.0.0.pom
+++ b/mrm-servlet/src/test/resources/local-repo-unit/org/group1/artifact1/2.0.0/artifact1-2.0.0.pom
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright MojoHaus and Contributors
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.example-group</groupId>
+  <artifactId>example-artifact</artifactId>
+  <version>2.0.0</version>
+  <packaging>pom</packaging>
+</project>

--- a/mrm-servlet/src/test/resources/local-repo-unit/org/group1/artifact1/2.0.0/artifact1-2.0.0.pom.sha1
+++ b/mrm-servlet/src/test/resources/local-repo-unit/org/group1/artifact1/2.0.0/artifact1-2.0.0.pom.sha1
@@ -1,0 +1,1 @@
+unit-test-ca766ba229dd04820042c13d24ef9fc76ceb2914

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
     <minimalMavenBuildVersion>3.6.3</minimalMavenBuildVersion>
     <mojo.java.target>8</mojo.java.target>
     <jetty.version>9.4.58.v20250814</jetty.version>
+    <mockito.version>4.11.0</mockito.version>
     <project.build.outputTimestamp>2023-11-02T22:53:14Z</project.build.outputTimestamp>
   </properties>
 
@@ -198,6 +199,11 @@
 
       <!-- commons -->
       <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>1.19.0</version>
+      </dependency>
+      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.20.0</version>
@@ -232,7 +238,13 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>4.11.0</version>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Maven 3.9+ can use it as smart checksums, so no additional files will be requested