### PR TITLE
Move Jetty code to separate module

### DIFF
--- a/mrm-maven-plugin/pom.xml
+++ b/mrm-maven-plugin/pom.xml
@@ -44,6 +44,11 @@
       <artifactId>mrm-servlet</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>mrm-servlet-jetty</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- Maven core -->
     <dependency>
@@ -95,24 +100,6 @@
     <dependency>
       <groupId>org.apache.maven.archetype</groupId>
       <artifactId>archetype-common</artifactId>
-    </dependency>
-
-    <!-- http server dependencies -->
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-servlet</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
     </dependency>
 
     <!-- commons -->

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/AbstractStartMojo.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/AbstractStartMojo.java
@@ -26,6 +26,7 @@ import org.codehaus.mojo.mrm.api.maven.ArtifactStore;
 import org.codehaus.mojo.mrm.impl.digest.AutoDigestFileSystem;
 import org.codehaus.mojo.mrm.impl.maven.ArtifactStoreFileSystem;
 import org.codehaus.mojo.mrm.impl.maven.CompositeArtifactStore;
+import org.codehaus.mojo.mrm.jetty.FileSystemServer;
 
 /**
  * Common base class for the mojos that start a repository.

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/RunMojo.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/RunMojo.java
@@ -21,6 +21,8 @@ import javax.inject.Inject;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.codehaus.mojo.mrm.jetty.FileSystemServer;
+import org.codehaus.mojo.mrm.jetty.FileSystemServerException;
 
 /**
  * This goal is used in-situ on a Maven project to allow integration tests based on the Maven Invoker to use a custom
@@ -51,17 +53,22 @@ public class RunMojo extends AbstractStartMojo {
         }
         FileSystemServer mrm = createFileSystemServer(createArtifactStore());
         getLog().info("Starting Mock Repository Manager");
-        mrm.ensureStarted();
-        String url = mrm.getUrl();
         try {
+            mrm.ensureStarted();
+            String url = mrm.getUrl();
+
             getLog().info("Mock Repository Manager " + url + " is started.");
             ConsoleScanner consoleScanner = new ConsoleScanner();
             consoleScanner.start();
             getLog().info("Hit ENTER on the console to stop the Mock Repository Manager and continue the build.");
             consoleScanner.waitForFinished();
+        } catch (FileSystemServerException fsse) {
+            throw new MojoExecutionException(fsse.getMessage(), fsse);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } finally {
+            String url = mrm.getUrl();
+
             getLog().info("Stopping Mock Repository Manager " + url);
             mrm.finish();
             try {

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/StartMojo.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/StartMojo.java
@@ -27,6 +27,8 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.mojo.mrm.jetty.FileSystemServer;
+import org.codehaus.mojo.mrm.jetty.FileSystemServerException;
 
 /**
  * This goal is used in-situ on a Maven project to allow integration tests based on the Maven Invoker to use a custom
@@ -53,7 +55,11 @@ public class StartMojo extends AbstractStartMojo {
     public void doExecute() throws MojoExecutionException, MojoFailureException {
         FileSystemServer mrm = createFileSystemServer(createArtifactStore());
         getLog().info("Starting Mock Repository Manager");
-        mrm.ensureStarted();
+        try {
+            mrm.ensureStarted();
+        } catch (FileSystemServerException e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
         String url = mrm.getUrl();
         getLog().info("Mock Repository Manager " + url + " is started.");
         if (!StringUtils.isEmpty(propertyName)) {

--- a/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/StopMojo.java
+++ b/mrm-maven-plugin/src/main/java/org/codehaus/mojo/mrm/plugin/StopMojo.java
@@ -22,6 +22,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.codehaus.mojo.mrm.jetty.FileSystemServer;
 
 /**
  * This goal is used in-situ on a Maven project to allow integration tests based on the Maven Invoker to use a custom

--- a/mrm-servlet-jetty/pom.xml
+++ b/mrm-servlet-jetty/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2011 Stephen Connolly
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>mrm</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mrm-servlet-jetty</artifactId>
+
+  <name>Mock Repository Manager :: Jetty Servlet</name>
+
+  <dependencies>
+    <!-- project dependencies -->
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>mrm-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>mrm-servlet</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- http server dependencies -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/mrm-servlet-jetty/src/main/java/org/codehaus/mojo/mrm/jetty/FileSystemServer.java
+++ b/mrm-servlet-jetty/src/main/java/org/codehaus/mojo/mrm/jetty/FileSystemServer.java
@@ -1,4 +1,4 @@
-package org.codehaus.mojo.mrm.plugin;
+package org.codehaus.mojo.mrm.jetty;
 
 /*
  * Copyright 2011 Stephen Connolly
@@ -16,7 +16,6 @@ package org.codehaus.mojo.mrm.plugin;
  * limitations under the License.
  */
 
-import org.apache.maven.plugin.MojoExecutionException;
 import org.codehaus.mojo.mrm.api.FileSystem;
 import org.codehaus.mojo.mrm.servlet.FileSystemServlet;
 import org.eclipse.jetty.server.Server;
@@ -145,9 +144,9 @@ public class FileSystemServer {
      * Ensures that the file system server is started (if already starting, will block until started, otherwise starts
      * the file system server and blocks until started)
      *
-     * @throws MojoExecutionException if the file system server could not be started.
+     * @throws FileSystemServerException if the file system server could not be started.
      */
-    public void ensureStarted() throws MojoExecutionException {
+    public void ensureStarted() throws FileSystemServerException {
         synchronized (lock) {
             if (started || starting) {
                 return;
@@ -170,7 +169,7 @@ public class FileSystemServer {
                 }
             }
         } catch (Exception e) {
-            throw new MojoExecutionException(e.getMessage(), e);
+            throw new FileSystemServerException(e.getMessage(), e);
         }
     }
 

--- a/mrm-servlet-jetty/src/main/java/org/codehaus/mojo/mrm/jetty/FileSystemServerException.java
+++ b/mrm-servlet-jetty/src/main/java/org/codehaus/mojo/mrm/jetty/FileSystemServerException.java
@@ -1,0 +1,25 @@
+package org.codehaus.mojo.mrm.jetty;
+
+/*
+ * Copyright MojoHaus and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+public class FileSystemServerException extends Exception {
+
+    public FileSystemServerException(String message, Exception exception) {
+        super(message, exception);
+    }
+}

--- a/mrm-servlet-jetty/src/main/java/org/codehaus/mojo/mrm/jetty/ServerLogger.java
+++ b/mrm-servlet-jetty/src/main/java/org/codehaus/mojo/mrm/jetty/ServerLogger.java
@@ -1,4 +1,4 @@
-package org.codehaus.mojo.mrm.plugin;
+package org.codehaus.mojo.mrm.jetty;
 
 /*
  * Copyright MojoHaus and Contributors

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
   <modules>
     <module>mrm-api</module>
     <module>mrm-servlet</module>
+    <module>mrm-servlet-jetty</module>
     <module>mrm-maven-plugin</module>
   </modules>
 


### PR DESCRIPTION
This is done in preparation of the jupiter extension to prevent duplicate code