### PR TITLE
Introduce support for FileNameTransformers

### DIFF
--- a/mrm-maven-plugin/src/site/markdown/repositories.md
+++ b/mrm-maven-plugin/src/site/markdown/repositories.md
@@ -35,6 +35,7 @@ A mock Maven repository that serves content from a local directory structure wit
 * `cloneTo` (optional) - Clone the source to a specific directory (useful for directory-based archives)
 * `cloneClean` (optional) - Ensure the cloneTo folder is cleaned before every run (default: false)
 * `lazyArchiver` (optional) - Set to `false` to archive directories at startup, or `true` to archive when used (default: false)
+* `transformDirectiveSource` (optional) - Set the name of the mechanism to transform in case of a directory based archive. Possible values: `metadata` (default: null)
 
 **Example:**
 
@@ -45,6 +46,7 @@ A mock Maven repository that serves content from a local directory structure wit
     <cloneTo>target/mock-repo</cloneTo>
     <cloneClean>true</cloneClean>
     <lazyArchiver>false</lazyArchiver>
+    <transformDirectiveSource>metadata</transformDirectiveSource>
   </mockRepo>
 </repositories>
 ```
@@ -60,6 +62,11 @@ The mockRepo recognizes the following file patterns in the source directory:
 * `archetype-catalog.xml` - Archetype catalog
 
 Supported archiver extensions include: `jar`, `zip`, `tar.gz`, `tgz`, `tar.xz`, and other formats supported by [Plexus Archiver](https://codehaus-plexus.github.io/plexus-archiver/).
+
+**Supported TransformDirectiveSource:**
+
+* metadata - Put a file called `.mrm-transform.properties` in the root of an archive directory (e.g. `artifactId-1.0.0.jar/.mrm-transform.properties`). This file supports the following entries
+  * [input].targetName = [output]
 
 ### localRepo
 

--- a/mrm-servlet/pom.xml
+++ b/mrm-servlet/pom.xml
@@ -87,6 +87,10 @@
       <artifactId>plexus-xml</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStore.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStore.java
@@ -177,23 +177,21 @@ public class MockArtifactStore extends BaseArtifactStore {
 
                     Content content;
                     if (mainFile.isDirectory()) {
-                    	DefaultFileSet fileSet = DefaultFileSet.fileSet(mainFile);
-                   	
+                        DefaultFileSet fileSet = DefaultFileSet.fileSet(mainFile);
+
                         if (transformDirectiveSourcFactory != null) {
                             TransformDirectiveSource transformDirectiveSource =
                                     transformDirectiveSourcFactory.newInstance(mainFile.toPath());
 
-                            new FileMapper[] fileMappers = new FileMapper[] {toFileMapper(transformDirectiveSource)};
+                            FileMapper[] fileMappers = new FileMapper[] {toFileMapper(transformDirectiveSource)};
                             fileSet.setFileMappers(fileMappers);
-                            
-                            InputStreamTransformer streamTransformer = toInputStreamTransformer(transformDirectiveSource);
+
+                            InputStreamTransformer streamTransformer =
+                                    toInputStreamTransformer(transformDirectiveSource);
                             fileSet.setStreamTransformer(dtreamTransformer);
                         }
                         content = new DirectoryContent(
-                                archiverManager,
-                                fileSet,
-                                lazyArchiver,
-                                pomArtifact.getTimestamp());
+                                archiverManager, fileSet, lazyArchiver, pomArtifact.getTimestamp());
                     } else {
                         content = new BytesContent(Utils.newEmptyJarContent(), pomArtifact.getTimestamp());
                     }
@@ -234,24 +232,22 @@ public class MockArtifactStore extends BaseArtifactStore {
 
                     Content content;
                     if (classifiedFile.isDirectory()) {
-                    	DefaultFileSet fileSet = DefaultFileSet.fileSet(classifiedFile);
-                       	
+                        DefaultFileSet fileSet = DefaultFileSet.fileSet(classifiedFile);
+
                         if (transformDirectiveSourcFactory != null) {
                             TransformDirectiveSource transformDirectiveSource =
                                     transformDirectiveSourcFactory.newInstance(classifiedFile.toPath());
 
-                            new FileMapper[] fileMappers = new FileMapper[] {toFileMapper(transformDirectiveSource)};
+                            FileMapper[] fileMappers = new FileMapper[] {toFileMapper(transformDirectiveSource)};
                             fileSet.setFileMappers(fileMappers);
-                            
-                            InputStreamTransformer streamTransformer = toInputStreamTransformer(transformDirectiveSource);
+
+                            InputStreamTransformer streamTransformer =
+                                    toInputStreamTransformer(transformDirectiveSource);
                             fileSet.setStreamTransformer(dtreamTransformer);
                         }
 
                         content = new DirectoryContent(
-                                archiverManager,
-                                fileSet,
-                                lazyArchiver,
-                                pomArtifact.getTimestamp());
+                                archiverManager, fileSet, lazyArchiver, pomArtifact.getTimestamp());
                     } else {
                         content = new FileContent(classifiedFile, pomArtifact.getTimestamp());
                     }
@@ -849,7 +845,7 @@ public class MockArtifactStore extends BaseArtifactStore {
         private final Archiver archiver;
 
         private final FileSet fileSet;
-        
+
         private File archivedFile;
 
         private String sha1Checksum;
@@ -861,14 +857,10 @@ public class MockArtifactStore extends BaseArtifactStore {
          * @param lastModified the last modified timestamp, or {@code null} to use the directory's last modified time
          * @since 1.0
          */
-        private DirectoryContent(
-                ArchiverManager archiverManager,
-                FileSet fileSet,
-                boolean lazy,
-                Long lastModified) {
+        private DirectoryContent(ArchiverManager archiverManager, FileSet fileSet, boolean lazy, Long lastModified) {
             this.fileSet = fileSet;
 
-        	File directory = fileSet.getDirectory();
+            File directory = fileSet.getDirectory();
             this.lastModified = lastModified != null ? lastModified : directory.lastModified();
 
             try {
@@ -886,8 +878,8 @@ public class MockArtifactStore extends BaseArtifactStore {
         }
 
         private void createArchive() {
-        	File directory = fileSet.getDirectory();
-        	
+            File directory = fileSet.getDirectory();
+
             synchronized (directory) {
                 archivedFile = new File(directory.getParentFile(), "_" + directory.getName());
                 archiver.setDestFile(archivedFile);

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStore.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStore.java
@@ -67,11 +67,16 @@ import org.codehaus.mojo.mrm.api.maven.ArtifactNotFoundException;
 import org.codehaus.mojo.mrm.api.maven.BaseArtifactStore;
 import org.codehaus.mojo.mrm.api.maven.MetadataNotFoundException;
 import org.codehaus.mojo.mrm.impl.Utils;
+import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSource;
+import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSourceFactory;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.ArchiverException;
+import org.codehaus.plexus.archiver.FileSet;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 import org.codehaus.plexus.archiver.util.DefaultFileSet;
+import org.codehaus.plexus.components.io.filemappers.FileMapper;
+import org.codehaus.plexus.components.io.functions.InputStreamTransformer;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -114,6 +119,11 @@ public class MockArtifactStore extends BaseArtifactStore {
         this(archiverManager, root, true);
     }
 
+    public MockArtifactStore(
+            ArchiverManager archiverManager, File root, TransformDirectiveSourceFactory transformDirectiveSource) {
+        this(archiverManager, root, true, transformDirectiveSource);
+    }
+
     /**
      * Create a mock artifact store by scanning for POMs within the specified root.
      *
@@ -122,6 +132,23 @@ public class MockArtifactStore extends BaseArtifactStore {
      * @since 1.0
      */
     public MockArtifactStore(ArchiverManager archiverManager, File root, boolean lazyArchiver) {
+        this(archiverManager, root, lazyArchiver, null);
+    }
+
+    /**
+     * Create a mock artifact store by scanning for POMs within the specified root.
+     *
+     * @param archiverManager
+     * @param root
+     * @param lazyArchiver
+     * @param transformDirectiveSource
+     * @since 2.0
+     */
+    public MockArtifactStore(
+            ArchiverManager archiverManager,
+            File root,
+            boolean lazyArchiver,
+            TransformDirectiveSourceFactory transformDirectiveSourcFactory) {
 
         if (!root.isDirectory()) {
             throw new IllegalArgumentException("The specified root must be a directory: " + root);
@@ -150,8 +177,23 @@ public class MockArtifactStore extends BaseArtifactStore {
 
                     Content content;
                     if (mainFile.isDirectory()) {
+                    	DefaultFileSet fileSet = DefaultFileSet.fileSet(mainFile);
+                   	
+                        if (transformDirectiveSourcFactory != null) {
+                            TransformDirectiveSource transformDirectiveSource =
+                                    transformDirectiveSourcFactory.newInstance(mainFile.toPath());
+
+                            new FileMapper[] fileMappers = new FileMapper[] {toFileMapper(transformDirectiveSource)};
+                            fileSet.setFileMappers(fileMappers);
+                            
+                            InputStreamTransformer streamTransformer = toInputStreamTransformer(transformDirectiveSource);
+                            fileSet.setStreamTransformer(dtreamTransformer);
+                        }
                         content = new DirectoryContent(
-                                archiverManager, mainFile, lazyArchiver, pomArtifact.getTimestamp());
+                                archiverManager,
+                                fileSet,
+                                lazyArchiver,
+                                pomArtifact.getTimestamp());
                     } else {
                         content = new BytesContent(Utils.newEmptyJarContent(), pomArtifact.getTimestamp());
                     }
@@ -192,8 +234,24 @@ public class MockArtifactStore extends BaseArtifactStore {
 
                     Content content;
                     if (classifiedFile.isDirectory()) {
+                    	DefaultFileSet fileSet = DefaultFileSet.fileSet(classifiedFile);
+                       	
+                        if (transformDirectiveSourcFactory != null) {
+                            TransformDirectiveSource transformDirectiveSource =
+                                    transformDirectiveSourcFactory.newInstance(classifiedFile.toPath());
+
+                            new FileMapper[] fileMappers = new FileMapper[] {toFileMapper(transformDirectiveSource)};
+                            fileSet.setFileMappers(fileMappers);
+                            
+                            InputStreamTransformer streamTransformer = toInputStreamTransformer(transformDirectiveSource);
+                            fileSet.setStreamTransformer(dtreamTransformer);
+                        }
+
                         content = new DirectoryContent(
-                                archiverManager, classifiedFile, lazyArchiver, pomArtifact.getTimestamp());
+                                archiverManager,
+                                fileSet,
+                                lazyArchiver,
+                                pomArtifact.getTimestamp());
                     } else {
                         content = new FileContent(classifiedFile, pomArtifact.getTimestamp());
                     }
@@ -224,6 +282,15 @@ public class MockArtifactStore extends BaseArtifactStore {
         if (archetypeCatalogFile.isFile()) {
             archetypeCatalog = new FileContent(archetypeCatalogFile, null);
         }
+    }
+
+    private FileMapper toFileMapper(TransformDirectiveSource source) {
+        return oldName -> source.plan().filename().apply(oldName);
+    }
+
+    private InputStreamTransformer toInputStreamTransformer(TransformDirectiveSource source) {
+        return (resource, inputstream) ->
+                source.plan().inputStream(resource.getName()).apply(inputstream);
     }
 
     private Artifact createPomArtifact(String groupId, String artifactId, String version, File file) {
@@ -777,12 +844,12 @@ public class MockArtifactStore extends BaseArtifactStore {
 
     private static class DirectoryContent implements Content {
 
-        private final File directory;
-
         private final Long lastModified;
 
         private final Archiver archiver;
 
+        private final FileSet fileSet;
+        
         private File archivedFile;
 
         private String sha1Checksum;
@@ -794,9 +861,14 @@ public class MockArtifactStore extends BaseArtifactStore {
          * @param lastModified the last modified timestamp, or {@code null} to use the directory's last modified time
          * @since 1.0
          */
-        private DirectoryContent(ArchiverManager archiverManager, File directory, boolean lazy, Long lastModified) {
+        private DirectoryContent(
+                ArchiverManager archiverManager,
+                FileSet fileSet,
+                boolean lazy,
+                Long lastModified) {
+            this.fileSet = fileSet;
 
-            this.directory = directory;
+        	File directory = fileSet.getDirectory();
             this.lastModified = lastModified != null ? lastModified : directory.lastModified();
 
             try {
@@ -814,10 +886,12 @@ public class MockArtifactStore extends BaseArtifactStore {
         }
 
         private void createArchive() {
+        	File directory = fileSet.getDirectory();
+        	
             synchronized (directory) {
                 archivedFile = new File(directory.getParentFile(), "_" + directory.getName());
                 archiver.setDestFile(archivedFile);
-                archiver.addFileSet(DefaultFileSet.fileSet(directory));
+                archiver.addFileSet(fileSet);
 
                 try {
                     archiver.setLastModifiedTime(Files.getLastModifiedTime(directory.toPath()));

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStore.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStore.java
@@ -141,7 +141,7 @@ public class MockArtifactStore extends BaseArtifactStore {
      * @param archiverManager
      * @param root
      * @param lazyArchiver
-     * @param transformDirectiveSource
+     * @param transformDirectiveSourcFactory
      * @since 2.0
      */
     public MockArtifactStore(
@@ -188,7 +188,7 @@ public class MockArtifactStore extends BaseArtifactStore {
 
                             InputStreamTransformer streamTransformer =
                                     toInputStreamTransformer(transformDirectiveSource);
-                            fileSet.setStreamTransformer(dtreamTransformer);
+                            fileSet.setStreamTransformer(streamTransformer);
                         }
                         content = new DirectoryContent(
                                 archiverManager, fileSet, lazyArchiver, pomArtifact.getTimestamp());
@@ -243,7 +243,7 @@ public class MockArtifactStore extends BaseArtifactStore {
 
                             InputStreamTransformer streamTransformer =
                                     toInputStreamTransformer(transformDirectiveSource);
-                            fileSet.setStreamTransformer(dtreamTransformer);
+                            fileSet.setStreamTransformer(streamTransformer);
                         }
 
                         content = new DirectoryContent(

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStore.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStore.java
@@ -138,11 +138,11 @@ public class MockArtifactStore extends BaseArtifactStore {
     /**
      * Create a mock artifact store by scanning for POMs within the specified root.
      *
-     * @param archiverManager
-     * @param root
-     * @param lazyArchiver
-     * @param transformDirectiveSourcFactory
-     * @since 2.0
+     * @param archiverManager the archivemanager
+     * @param root the root
+     * @param lazyArchiver archive lazily or nor
+     * @param transformDirectiveSourcFactory the transformDirectiveSourcFactory
+     * @since 2.0.0
      */
     public MockArtifactStore(
             ArchiverManager archiverManager,
@@ -286,7 +286,7 @@ public class MockArtifactStore extends BaseArtifactStore {
 
     private InputStreamTransformer toInputStreamTransformer(TransformDirectiveSource source) {
         return (resource, inputstream) ->
-                source.plan().inputStream(resource.getName()).apply(inputstream);
+                source.plan().content(resource.getName()).apply(inputstream);
     }
 
     private Artifact createPomArtifact(String groupId, String artifactId, String version, File file) {

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/FileTransformPlan.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/FileTransformPlan.java
@@ -1,0 +1,15 @@
+package org.codehaus.mojo.mrm.impl.transform;
+
+import java.io.InputStream;
+import java.util.function.UnaryOperator;
+
+public interface FileTransformPlan {
+
+    default UnaryOperator<String> filename() {
+        return UnaryOperator.identity();
+    }
+
+    default UnaryOperator<InputStream> inputStream(String fileName) {
+        return UnaryOperator.identity();
+    }
+}

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/FileTransformPlan.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/FileTransformPlan.java
@@ -3,13 +3,31 @@ package org.codehaus.mojo.mrm.impl.transform;
 import java.io.InputStream;
 import java.util.function.UnaryOperator;
 
+/**
+ * A FileTransformPlan provides all methods to the transformations.
+ * All transformations start with calling the transformation result for a filename.
+ * All other methods use a filename as context to be able to do their transformation.
+ * The implementation is responsible for choosing the old filename or new filename.
+ * e.g The Plexus Archiver uses FileSets with InputStreamTransformer, which is based on the new filename.
+ *
+ * @since 2.0.0
+ */
 public interface FileTransformPlan {
 
+    /**
+     *
+     * @return the filename transformation instruction, by default no transformation
+     */
     default UnaryOperator<String> filename() {
         return UnaryOperator.identity();
     }
 
-    default UnaryOperator<InputStream> inputStream(String fileName) {
+    /**
+     *
+     * @param fileName the context
+     * @return the content transformation instruction, by default no transformation
+     */
+    default UnaryOperator<InputStream> content(String fileName) {
         return UnaryOperator.identity();
     }
 }

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/TransformDirectiveSource.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/TransformDirectiveSource.java
@@ -15,7 +15,16 @@
  */
 package org.codehaus.mojo.mrm.impl.transform;
 
+/**
+ * Provides a fileTransformationPlan based on the centralized or decentralized sources, as defined by the implementation.
+ *
+ * @since 2.0.0
+ */
 public interface TransformDirectiveSource {
 
+    /**
+     *
+     * @return the plan, never {@code null}
+     */
     FileTransformPlan plan();
 }

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/TransformDirectiveSource.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/TransformDirectiveSource.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.impl.transform;
+
+public interface TransformDirectiveSource {
+
+    FileTransformPlan plan();
+}

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/TransformDirectiveSourceFactory.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/TransformDirectiveSourceFactory.java
@@ -17,9 +17,25 @@ package org.codehaus.mojo.mrm.impl.transform;
 
 import java.nio.file.Path;
 
+/**
+ * Factory for a named TransformDirectiveSource. Prepared to be used for either CDI or SPI.
+ *
+ * @since 2.0.0
+ */
 public interface TransformDirectiveSourceFactory {
 
+    /**
+     * The name, might be used for lookup.
+     *
+     * @return the name, never {@code null}
+     */
     String name();
 
+    /**
+     * Returns a specific transformationDirectiveSource for a single directory archive.
+     *
+     * @param root the directory archive, never {@code null}
+     * @return the transformDirectiveSource, never {@code null}
+     */
     TransformDirectiveSource newInstance(Path root);
 }

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/TransformDirectiveSourceFactory.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/TransformDirectiveSourceFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.impl.transform;
+
+import java.nio.file.Path;
+
+public interface TransformDirectiveSourceFactory {
+
+    String name();
+
+    TransformDirectiveSource newInstance(Path root);
+}

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/metadata/MetadataTransformDirective.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/metadata/MetadataTransformDirective.java
@@ -26,12 +26,29 @@ import java.util.function.UnaryOperator;
 import org.codehaus.mojo.mrm.impl.transform.FileTransformPlan;
 import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSource;
 
+/**
+ * <p>
+ * Provides a plan based on {@code ".mrm-transform.properties"}.
+ * </p>
+ *
+ * Supports:
+ * <dl>
+ *   <dt>[inputName].target=[output]</dt>
+ *   <dd>Transform the filename  from input to output</dd>
+ * </dl>
+ *
+ * @since 2.0.0
+ */
 public final class MetadataTransformDirective implements TransformDirectiveSource {
 
     private final Path metadataFile = Path.of(".mrm-transform.properties");
 
     private final Properties properties;
 
+    /**
+     *
+     * @param root the archive directory
+     */
     public MetadataTransformDirective(Path root) {
         this.properties = new Properties();
 

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/metadata/MetadataTransformDirective.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/metadata/MetadataTransformDirective.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.impl.transform.metadata;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.function.UnaryOperator;
+
+import org.codehaus.mojo.mrm.impl.transform.FileTransformPlan;
+import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSource;
+
+public final class MetadataTransformDirective implements TransformDirectiveSource {
+
+    private final Path metadataFile = Path.of(".mrm-transform.properties");
+
+    private final Properties properties;
+
+    public MetadataTransformDirective(Path root) {
+        this.properties = new Properties();
+
+        try (InputStream in = Files.newInputStream(root.resolve(metadataFile))) {
+            properties.load(in);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public FileTransformPlan plan() {
+        return new MetadataTransformPlan(key -> properties.getProperty(key + ".targetName", key));
+    }
+
+    private static class MetadataTransformPlan implements FileTransformPlan {
+
+        private final UnaryOperator<String> filenameTransformer;
+
+        MetadataTransformPlan(UnaryOperator<String> filenameTransformer) {
+            this.filenameTransformer = filenameTransformer;
+        }
+
+        @Override
+        public UnaryOperator<String> filename() {
+            return filenameTransformer;
+        }
+    }
+}

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/metadata/MetadataTransformDirectiveFactory.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/metadata/MetadataTransformDirectiveFactory.java
@@ -20,6 +20,11 @@ import java.nio.file.Path;
 import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSource;
 import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSourceFactory;
 
+/**
+ * The Factory for a MetadataTransformDirective
+ *
+ * @since 2.0.0
+ */
 public final class MetadataTransformDirectiveFactory implements TransformDirectiveSourceFactory {
 
     @Override

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/metadata/MetadataTransformDirectiveFactory.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/transform/metadata/MetadataTransformDirectiveFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.impl.transform.metadata;
+
+import java.nio.file.Path;
+
+import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSource;
+import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSourceFactory;
+
+public final class MetadataTransformDirectiveFactory implements TransformDirectiveSourceFactory {
+
+    @Override
+    public String name() {
+        return "metadata";
+    }
+
+    @Override
+    public TransformDirectiveSource newInstance(Path root) {
+        return new MetadataTransformDirective(root);
+    }
+}

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/plugin/MockRepo.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/plugin/MockRepo.java
@@ -48,7 +48,7 @@ public class MockRepo implements ArtifactStoreFactory {
 
     /**
      * Define where the transformation directives are coming from. Supported values: metadata.
-     * 
+     *
      * @since 2.0.0
      * @see MetadataTransformDirective
      */
@@ -84,7 +84,8 @@ public class MockRepo implements ArtifactStoreFactory {
         } else {
             tds = switch (transformDirectiveSource) {
                 case "metadata" -> new MetadataTransformDirectiveFactory();
-                default -> throw new IllegalArgumentException("Unknown transformDirectiveSource: " + transformDirectiveSource);
+                default ->
+                    throw new IllegalArgumentException("Unknown transformDirectiveSource: " + transformDirectiveSource);
             };
         }
 

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/plugin/MockRepo.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/plugin/MockRepo.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.codehaus.mojo.mrm.api.maven.ArtifactStore;
 import org.codehaus.mojo.mrm.impl.maven.MockArtifactStore;
+import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSourceFactory;
+import org.codehaus.mojo.mrm.impl.transform.metadata.MetadataTransformDirective;
+import org.codehaus.mojo.mrm.impl.transform.metadata.MetadataTransformDirectiveFactory;
 
 /**
  * A mock Maven repository.
@@ -43,6 +46,14 @@ public class MockRepo implements ArtifactStoreFactory {
      */
     private boolean lazyArchiver;
 
+    /**
+     * Define where the transformation directives are coming from. Supported values: metadata.
+     * 
+     * @since 2.0.0
+     * @see MetadataTransformDirective
+     */
+    private String transformDirectiveSource;
+
     @Override
     public ArtifactStore newInstance(FactoryHelper factoryHelper) {
         if (source == null) {
@@ -67,7 +78,17 @@ public class MockRepo implements ArtifactStoreFactory {
             }
         }
 
-        return new MockArtifactStore(factoryHelper.getArchiverManager(), root, lazyArchiver);
+        TransformDirectiveSourceFactory tds;
+        if (transformDirectiveSource == null) {
+            tds = null;
+        } else {
+            tds = switch (transformDirectiveSource) {
+                case "metadata" -> new MetadataTransformDirectiveFactory();
+                default -> throw new IllegalArgumentException("Unknown transformDirectiveSource: " + transformDirectiveSource);
+            };
+        }
+
+        return new MockArtifactStore(factoryHelper.getArchiverManager(), root, lazyArchiver, tds);
     }
 
     /**

--- a/mrm-servlet/src/test/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStoreTest.java
+++ b/mrm-servlet/src/test/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStoreTest.java
@@ -27,6 +27,7 @@ import org.apache.maven.artifact.repository.metadata.Metadata;
 import org.apache.maven.artifact.repository.metadata.SnapshotVersion;
 import org.codehaus.mojo.mrm.api.maven.Artifact;
 import org.codehaus.mojo.mrm.api.maven.MetadataNotFoundException;
+import org.codehaus.mojo.mrm.impl.transform.metadata.MetadataTransformDirectiveFactory;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.testing.PlexusTest;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
@@ -490,5 +492,31 @@ class MockArtifactStoreTest extends AbstractTestSupport {
                 .filter(v -> "jar".equals(v.getExtension()))
                 .filter(v -> !v.getUpdated().isEmpty())
                 .anyMatch(v -> "1.0-SNAPSHOT".equals(v.getVersion())));
+    }
+
+    @Test
+    void directoryTransform() throws Exception {
+        MockArtifactStore artifactStore = new MockArtifactStore(
+                archiverManager, getResourceAsFile("/directory-transform"), new MetadataTransformDirectiveFactory());
+
+        Artifact mainArtifact = new Artifact("localhost", "directory-transform", "1.0", "jar");
+        InputStream inputStreamJar = artifactStore.get(mainArtifact);
+        assertNotNull(inputStreamJar);
+
+        List<String> names = new ArrayList<>();
+
+        File jarFile = Files.createTempFile(temporaryFolder, "test", ".jar").toFile();
+        Files.copy(inputStreamJar, jarFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+
+        try (JarFile jar = new JarFile(jarFile)) {
+            Enumeration<JarEntry> entries = jar.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry entry = entries.nextElement();
+                names.add(entry.getName());
+            }
+        }
+
+        assertTrue(names.contains("module-info.class"));
+        assertFalse(names.contains("module-info.java"));
     }
 }

--- a/mrm-servlet/src/test/resources/directory-transform/directory-transform-1.0.jar/.mrm-transform.properties
+++ b/mrm-servlet/src/test/resources/directory-transform/directory-transform-1.0.jar/.mrm-transform.properties
@@ -1,0 +1,1 @@
+module-info.java.targetName=module-info.class

--- a/mrm-servlet/src/test/resources/directory-transform/directory-transform-1.0.pom
+++ b/mrm-servlet/src/test/resources/directory-transform/directory-transform-1.0.pom
@@ -1,0 +1,6 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>directory-transform</artifactId>
+  <version>1.0</version>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -294,25 +294,6 @@
         <artifactId>sisu-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>check-java</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-            <configuration>
-              <signature>
-                <groupId>org.codehaus.mojo.signature</groupId>
-                <artifactId>java18</artifactId>
-                <version>1.0</version>
-              </signature>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <!-- multi module project - stage site -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,11 @@
         <artifactId>plexus-archiver</artifactId>
         <version>4.12.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-io</artifactId>
+        <version>3.6.0</version>
+      </dependency>
 
       <!-- testing -->
       <dependency>


### PR DESCRIPTION
This feature will make it possible to transform the filename and its data of mock repositories.

This can be done by settings the TransformDirectiveSource for the mockReposity.
Currently only metadata is supported, which means it reads its directives from the `.mrm-transform.properties`.
There might be an "inline" in the future, which reads the directives from the file itself.

I'll work on a classfile-api contentTransformer, starting the support of module-info.java to module-info.class.
With this you'll have readable files as source, having binary files as output without the need for calling javac.


