### PR TITLE
Introduce Jupiter Extension

### DIFF
--- a/mrm-jupiter-extension/pom.xml
+++ b/mrm-jupiter-extension/pom.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2026 Robert Scholte
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.codehaus.mojo</groupId>
+    <artifactId>mrm</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mrm-jupiter-extension</artifactId>
+
+  <name>Mock Repository Manager :: Jupiter Extension</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>mrm-api</artifactId>
+      <version>2.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>mrm-servlet</artifactId>
+      <version>2.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>mrm-servlet-jetty</artifactId>
+      <version>2.0.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-archiver</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- artifact resolver -->
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-resolver-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-http</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven.archetype</groupId>
+      <artifactId>archetype-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>6.0.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.27.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/mrm-jupiter-extension/src/it/resources/local-repo/repositories/dev/groupid/artifactid/4.2/artifactid-4.2-meta.properties
+++ b/mrm-jupiter-extension/src/it/resources/local-repo/repositories/dev/groupid/artifactid/4.2/artifactid-4.2-meta.properties
@@ -1,0 +1,1 @@
+downdload.artifactid-4.2-meta.properties=success

--- a/mrm-jupiter-extension/src/it/resources/local-repo/repositories/dev/groupid/artifactid/4.2/artifactid-4.2-meta.properties
+++ b/mrm-jupiter-extension/src/it/resources/local-repo/repositories/dev/groupid/artifactid/4.2/artifactid-4.2-meta.properties
@@ -1,1 +1,1 @@
-downdload.artifactid-4.2-meta.properties=success
+download.artifactid-4.2-meta.properties=success

--- a/mrm-jupiter-extension/src/it/resources/local-repo/repositories/dev/groupid/artifactid/4.2/artifactid-4.2.txt
+++ b/mrm-jupiter-extension/src/it/resources/local-repo/repositories/dev/groupid/artifactid/4.2/artifactid-4.2.txt
@@ -1,0 +1,1 @@
+Downloaded artifactid-4.2.txt successfully

--- a/mrm-jupiter-extension/src/it/resources/mock-repo/directory-transform/directory-transform-1.0.jar/.mrm-transform.properties
+++ b/mrm-jupiter-extension/src/it/resources/mock-repo/directory-transform/directory-transform-1.0.jar/.mrm-transform.properties
@@ -1,0 +1,2 @@
+module-info.java.targetName=module-info.class
+module-info.java.contentTransformers=javaToClass

--- a/mrm-jupiter-extension/src/it/resources/mock-repo/directory-transform/directory-transform-1.0.jar/module-info.java
+++ b/mrm-jupiter-extension/src/it/resources/mock-repo/directory-transform/directory-transform-1.0.jar/module-info.java
@@ -1,0 +1,4 @@
+module localhost.directory.transform {
+	requires localhost.lib;
+	requires static localhost.log.api;
+}

--- a/mrm-jupiter-extension/src/it/resources/mock-repo/directory-transform/directory-transform-1.0.pom
+++ b/mrm-jupiter-extension/src/it/resources/mock-repo/directory-transform/directory-transform-1.0.pom
@@ -1,0 +1,6 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>localhost</groupId>
+  <artifactId>directory-transform</artifactId>
+  <version>1.0</version>
+</project>

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/Directory.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/Directory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * A reference to a directory.
+ * Its value intentionally does not support placeholders.
+ * To move it outside of the project (e.g. temp directory or user home) provide a non-argument constructor implementation of PathResolver
+ *
+ * @since 2.0
+ */
+public @interface Directory {
+
+    /**
+     *
+     * @return the class that will resolve the basePath
+     *
+     * @see UserHomePathResolver
+     */
+    Class<? extends PathResolver> baseBathResolver() default UserDirPathResolver.class;
+
+    /**
+     * This value must be relative and must give the same result after normalizing.
+     *
+     * @return the path
+     * @see Paths#get(String, String...)
+     * @see Path#resolve(String)
+     */
+    String value();
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/DirectoryResolver.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/DirectoryResolver.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.nio.file.Path;
+
+/**
+ * Utility class that resolves the directory and prevents path traversal
+ *
+ * @since 2.0.0
+ */
+final class DirectoryResolver {
+
+    static Path resolve(Directory directory) {
+        PathResolver basePathResolver = getBasePathResolver(directory);
+
+        Path basePath = basePathResolver.resolve().toAbsolutePath();
+
+        Path targetPath = Path.of(directory.value());
+        if (targetPath.isAbsolute()) {
+            throw new IllegalArgumentException("path of @CacheDirectory must be relative");
+        }
+
+        Path targetDirectory = basePath.resolve(targetPath);
+        if (!targetDirectory.startsWith(basePath)) {
+            throw new SecurityException("Path traversal not allowed");
+        }
+
+        return targetDirectory;
+    }
+
+    private static PathResolver getBasePathResolver(Directory directory) {
+        try {
+            return directory.baseBathResolver().getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(directory.baseBathResolver() + " is missing default constructor");
+        }
+    }
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/FileUtils.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/FileUtils.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.codehaus.mojo.mrm.jupiter;
 
 import java.io.IOException;

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/FileUtils.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/FileUtils.java
@@ -1,0 +1,64 @@
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+/**
+ * Common operations on directories
+ *
+ * @since 2.0.0
+ */
+final class FileUtils {
+
+    private FileUtils() {}
+
+    static void cleanDirectory(Path rootDir) throws IOException {
+        if (!Files.exists(rootDir)) {
+            throw new IllegalArgumentException("Directory does not exist: " + rootDir);
+        }
+
+        try (Stream<Path> stream = Files.walk(rootDir)) {
+            stream.sorted(Comparator.reverseOrder()) // Deletes children files before parent folders
+                    .filter(path -> !path.equals(rootDir)) // Prevents deleting the target root folder itself
+                    .forEach(path -> {
+                        try {
+                            Files.delete(path);
+                        } catch (IOException e) {
+                            throw new UncheckedIOException("Failed to delete: " + path, e);
+                        }
+                    });
+        }
+    }
+
+    static void copyDirectory(Path source, Path target) throws IOException {
+        if (!Files.exists(source)) {
+            throw new IllegalArgumentException("Source directory does not exist: " + source);
+        }
+
+        try (Stream<Path> stream = Files.walk(source)) {
+            stream.forEach(sourcePath -> {
+                Path targetPath = target.resolve(source.relativize(sourcePath));
+                try {
+                    if (Files.isDirectory(sourcePath)) {
+                        if (!Files.exists(targetPath)) {
+                            Files.createDirectories(targetPath);
+                        }
+                    } else {
+                        Files.copy(
+                                sourcePath,
+                                targetPath,
+                                StandardCopyOption.REPLACE_EXISTING,
+                                StandardCopyOption.COPY_ATTRIBUTES);
+                    }
+                } catch (IOException e) {
+                    throw new UncheckedIOException("Failed to copy from " + sourcePath + " to " + targetPath, e);
+                }
+            });
+        }
+    }
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/HostedRepo.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/HostedRepo.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation based representation of {@link org.codehaus.mojo.mrm.plugin.HostedRepo}
+ *
+ * @since 2.0.0
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface HostedRepo {
+
+    /**
+     * Path to the directory where uploaded artifacts will be stored.
+     * The directory will be created if it does not already exist.
+     *
+     * @return path to the repository target directory
+     */
+    Directory target();
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/LocalRepo.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/LocalRepo.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.lang.annotation.Retention;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation based implementation of {@link org.codehaus.mojo.mrm.plugin.LocalRepo}
+ *
+ * @since 2.0.0
+ */
+@Retention(RUNTIME)
+public @interface LocalRepo {
+
+    /**
+     * Path to the directory containing the local Maven repository.
+     *
+     * @return path to the repository source directory
+     */
+    Directory source();
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepo.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepo.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.lang.annotation.Retention;
+
+import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSourceFactory;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation based representation of {@link org.codehaus.mojo.mrm.plugin.MockRepo}
+ * @since 2.0.0
+ */
+@Retention(RUNTIME)
+public @interface MockRepo {
+
+    /**
+     * Path to the directory containing the mock repository content.
+     *
+     * @return path to the mock repository source directory
+     */
+    Directory source();
+
+    /**
+     * If set, the {@link #source()} directory will be cloned to this path before the server starts.
+     * This is useful in case additional files are generated.
+     * Relative paths are resolved against the result of baseBathResolverm which defaults to the working directory.
+     *
+     * @return path to the clone target directory, or empty string to skip cloning
+     */
+    Directory cloneTo() default @Directory(value = "", baseBathResolver = SourcePathResolver.class);
+
+    /**
+     * When {@link #cloneTo()} is set, controls whether the clone target directory is cleaned
+     * before copying. Defaults to {@code false}.
+     *
+     * @return {@code true} to clean the clone target before each run
+     */
+    boolean cloneClean() default false;
+
+    /**
+     * Controls whether directory content is archived lazily (on first access) or eagerly at startup.
+     * Defaults to {@code true} (lazy).
+     *
+     * @return {@code true} to archive directory content on demand
+     */
+    boolean lazyArchiver() default true;
+
+    Class<? extends TransformDirectiveSourceFactory> transformDirectiveSource() default
+            NoOpTransformDirectiveSourceFactory.class;
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManager.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManager.java
@@ -73,14 +73,14 @@ public @interface MockRepositoryManager {
     HostedRepo[] hostedRepos() default {};
 
     /**
-     * The remote repositories for downloading artifacts. Within the Maven context these are
+     * The system for handling downloading artifacts from remote repositories. Within the Maven context these are
      * the repositories defined in the pom.xml, having central defined as the default.
      *
      * @return the local repository configurations
      * @see LocalRepo
      */
-    RemoteRepositories remoteRepositories() default
-            @RemoteRepositories(
+    RemoteArtifactSystem remoteArtifactSystem() default
+            @RemoteArtifactSystem(
                     cacheDirectory = @Directory(value = ""),
                     repositories = {});
 }

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManager.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManager.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * The annotation to make use the mock repository manager.
+ * Its options should be similar to the mrm-maven-plugin configuration
+ *
+ * @since 2.0.0
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+@ExtendWith(MockRepositoryManagerExtension.class)
+public @interface MockRepositoryManager {
+
+    /**
+     * The port to start the server on. Defaults to {@code 0} which means a random available port will be chosen.
+     *
+     * @return the port number
+     */
+    int port() default 0;
+
+    /**
+     * The base context path for the server. Defaults to {@code "/"}.
+     *
+     * @return the context path
+     */
+    String basePath() default "/";
+
+    /**
+     * Mock repositories whose artifact content is derived from POM files in the source directory.
+     *
+     * @return the mock repository configurations
+     * @see MockRepo
+     */
+    MockRepo[] mockRepos() default {};
+
+    /**
+     * Locally stored Maven repositories served read-only from a directory on disk.
+     *
+     * @return the local repository configurations
+     * @see LocalRepo
+     */
+    LocalRepo[] localRepos() default {};
+
+    /**
+     * Hosted repositories that accept artifact uploads (distribution management).
+     *
+     * @return the hosted repository configurations
+     * @see HostedRepo
+     */
+    HostedRepo[] hostedRepos() default {};
+
+    /**
+     * The remote repositories for downloading artifacts. Within the Maven context these are
+     * the repositories defined in the pom.xml, having central defined as the default.
+     *
+     * @return the local repository configurations
+     * @see LocalRepo
+     */
+    RemoteRepositories remoteRepositories() default
+            @RemoteRepositories(
+                    cacheDirectory = @Directory(value = ""),
+                    repositories = {});
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManagerExtension.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManagerExtension.java
@@ -193,7 +193,7 @@ class MockRepositoryManagerExtension implements BeforeAllCallback, AfterAllCallb
             stores.add(new DiskArtifactStore(targetDirectory.toFile()).canWrite(true));
         }
 
-        RemoteRepositories remoteRepositories = annotation.remoteRepositories();
+        RemoteArtifactSystem remoteRepositories = annotation.remoteArtifactSystem();
 
         if (remoteRepositories.repositories().length > 0) {
             List<RemoteRepository> remoteRepos = Arrays.stream(remoteRepositories.repositories())

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManagerExtension.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManagerExtension.java
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import javax.inject.Provider;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
+import org.codehaus.mojo.mrm.api.maven.ArtifactStore;
+import org.codehaus.mojo.mrm.impl.digest.AutoDigestFileSystem;
+import org.codehaus.mojo.mrm.impl.maven.ArtifactStoreFileSystem;
+import org.codehaus.mojo.mrm.impl.maven.CompositeArtifactStore;
+import org.codehaus.mojo.mrm.impl.maven.DiskArtifactStore;
+import org.codehaus.mojo.mrm.impl.maven.MockArtifactStore;
+import org.codehaus.mojo.mrm.impl.maven.ProxyArtifactStore;
+import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSourceFactory;
+import org.codehaus.mojo.mrm.jetty.FileSystemServer;
+import org.codehaus.mojo.mrm.jetty.FileSystemServerException;
+import org.codehaus.mojo.mrm.plugin.FactoryHelper;
+import org.codehaus.plexus.archiver.Archiver;
+import org.codehaus.plexus.archiver.ear.EarArchiver;
+import org.codehaus.plexus.archiver.jar.JarArchiver;
+import org.codehaus.plexus.archiver.manager.ArchiverManager;
+import org.codehaus.plexus.archiver.manager.DefaultArchiverManager;
+import org.codehaus.plexus.archiver.war.WarArchiver;
+import org.codehaus.plexus.archiver.zip.ZipArchiver;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
+import org.eclipse.aether.impl.DefaultServiceLocator;
+import org.eclipse.aether.internal.impl.DefaultRepositorySystem;
+import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.repository.LocalRepositoryManager;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
+import org.eclipse.aether.spi.connector.transport.TransporterFactory;
+import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.StoreScope;
+import org.junit.jupiter.api.extension.ExtensionContextException;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * The extension for preparing the mrm-server based on the {@link MockRepositoryManager} annotation and
+ * exposing relevant settings via {@link MockRepositoryManagerServer}
+ *
+ * @since 2.0.0
+ */
+class MockRepositoryManagerExtension implements BeforeAllCallback, AfterAllCallback, ParameterResolver {
+
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create(MockRepositoryManagerExtension.class);
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        MockRepositoryManager annotation = context.getRequiredTestClass().getAnnotation(MockRepositoryManager.class);
+
+        ExtensionContext.Store rootStore = context.getStore(StoreScope.EXECUTION_REQUEST, NAMESPACE);
+
+        RepositorySystemHandler repositorySystemSupplier = rootStore.computeIfAbsent(
+                RepositorySystemHandler.class, key -> createRepositorySystem(), RepositorySystemHandler.class);
+
+        rootStore.computeIfAbsent(annotation, key -> {
+            try {
+                return createServerSource(annotation, repositorySystemSupplier);
+            } catch (FileSystemServerException e) {
+                throw new ExtensionContextException("Failed to create a ServerSource", e);
+            }
+        });
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+            throws ParameterResolutionException {
+        return parameterContext.getParameter().getType().equals(MockRepositoryManagerServer.class);
+    }
+
+    @Override
+    public @Nullable MockRepositoryManagerServer resolveParameter(
+            ParameterContext parameterContext, ExtensionContext extensionContext) throws ParameterResolutionException {
+        MockRepositoryManager annotation =
+                extensionContext.getRequiredTestClass().getAnnotation(MockRepositoryManager.class);
+
+        ServerResource resource = extensionContext
+                .getStore(StoreScope.EXECUTION_REQUEST, NAMESPACE)
+                .get(annotation, ServerResource.class);
+        if (resource == null) {
+            throw new ParameterResolutionException(
+                    "MockRepositoryManagerServer is not available. Make sure the test class is annotated with @MockRepositoryManager.");
+        }
+        return resource.getHandle();
+    }
+
+    private RepositorySystemHandler createRepositorySystem() {
+        DefaultRepositorySystem repositorySystem = new DefaultRepositorySystem();
+        DefaultServiceLocator serviceLocator = MavenRepositorySystemUtils.newServiceLocator();
+        serviceLocator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
+        // Registreer de HTTP transport factory
+        serviceLocator.addService(TransporterFactory.class, HttpTransporterFactory.class);
+
+        repositorySystem.initService(serviceLocator);
+
+        return new RepositorySystemHandler(repositorySystem);
+    }
+
+    private ServerResource createServerSource(
+            MockRepositoryManager mockRepositoryManager, Supplier<RepositorySystem> repoSystemSupplier)
+            throws FileSystemServerException {
+        FileSystemServer mrm = createFileSystemServer(mockRepositoryManager, repoSystemSupplier);
+
+        mrm.ensureStarted();
+
+        MockRepositoryManagerServer handle = new MockRepositoryManagerServer(mrm.getUrl());
+
+        return new ServerResource(mrm, handle);
+    }
+
+    /**
+     * Creates a file system server from an artifact store.
+     *
+     * @param artifactStore the artifact store to serve.
+     * @return the file system server.
+     */
+    private FileSystemServer createFileSystemServer(
+            MockRepositoryManager mockRepositoryManager, Supplier<RepositorySystem> repoSystemSupplier) {
+        int port = mockRepositoryManager.port();
+        String basePath = mockRepositoryManager.basePath();
+        ArtifactStore artifactStore = createArtifactStore(mockRepositoryManager, repoSystemSupplier);
+
+        return new FileSystemServer(
+                "mrm-fileserver",
+                Math.max(0, Math.min(port, 65535)),
+                basePath,
+                new AutoDigestFileSystem(new ArtifactStoreFileSystem(artifactStore)),
+                true);
+    }
+
+    private ArtifactStore createArtifactStore(
+            MockRepositoryManager annotation, Supplier<RepositorySystem> repoSystemSupplier) {
+        List<ArtifactStore> stores = new ArrayList<>();
+
+        for (MockRepo mockRepo : annotation.mockRepos()) {
+            stores.add(createMockRepoStore(mockRepo));
+        }
+        for (LocalRepo localRepo : annotation.localRepos()) {
+            Path sourceDirectory = DirectoryResolver.resolve(localRepo.source());
+
+            stores.add(new DiskArtifactStore(sourceDirectory.toFile()));
+        }
+        for (HostedRepo hostedRepo : annotation.hostedRepos()) {
+            Path target = DirectoryResolver.resolve(hostedRepo.target());
+
+            Path targetDirectory;
+            try {
+                targetDirectory = Files.createDirectories(target);
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to create hosted repository directory: " + target);
+            }
+            stores.add(new DiskArtifactStore(targetDirectory.toFile()).canWrite(true));
+        }
+
+        RemoteRepositories remoteRepositories = annotation.remoteRepositories();
+
+        if (remoteRepositories.repositories().length > 0) {
+            List<RemoteRepository> remoteRepos = Arrays.stream(remoteRepositories.repositories())
+                    .map(MockRepositoryManagerExtension::toRemoteRepository)
+                    .toList();
+
+            DefaultRepositorySystemSession repositorySystemSession = MavenRepositorySystemUtils.newSession();
+
+            LocalRepository cacheDirectory = toLocalRepository(remoteRepositories.cacheDirectory());
+
+            RepositorySystem repositorySystem = repoSystemSupplier.get();
+            LocalRepositoryManager localRepositoryManager =
+                    repositorySystem.newLocalRepositoryManager(repositorySystemSession, cacheDirectory);
+
+            repositorySystemSession.setLocalRepositoryManager(localRepositoryManager);
+            repositorySystemSession.setReadOnly();
+
+            FactoryHelper factoryHelper = new StandaloneFactoryHelper(
+                    repositorySystem, repositorySystemSession, remoteRepos, createArchiverManager());
+
+            stores.add(new ProxyArtifactStore(factoryHelper));
+        }
+
+        int storeCount = stores.size();
+        if (storeCount == 0) {
+            throw new IllegalStateException("At least 1 repository required");
+        } else if (storeCount == 1) {
+            return stores.get(0);
+        } else {
+            ArtifactStore[] artifactStores = stores.toArray(new ArtifactStore[0]);
+            return new CompositeArtifactStore(artifactStores);
+        }
+    }
+
+    private ArtifactStore createMockRepoStore(MockRepo mockRepo) {
+        Path root = DirectoryResolver.resolve(mockRepo.source());
+
+        if (mockRepo.cloneTo().baseBathResolver() != SourcePathResolver.class) {
+            Path cloneTarget = DirectoryResolver.resolve(mockRepo.cloneTo());
+
+            if (Files.isDirectory(cloneTarget) && mockRepo.cloneClean()) {
+                try {
+                    FileUtils.cleanDirectory(cloneTarget);
+                } catch (IOException e) {
+                    throw new IllegalStateException("Failed to clean directory: " + e.getMessage(), e);
+                }
+            } else if (Files.isRegularFile(cloneTarget)) {
+                throw new IllegalStateException("Failed to create clone target directory: " + cloneTarget);
+            }
+
+            try {
+                Path cloneDirectory = Files.createDirectories(cloneTarget);
+                FileUtils.copyDirectory(root, cloneDirectory);
+                root = cloneTarget;
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to copy directory: " + e.getMessage(), e);
+            }
+        }
+
+        TransformDirectiveSourceFactory transformDirectiveSourceFactory;
+        if (mockRepo.transformDirectiveSource() == NoOpTransformDirectiveSourceFactory.class) {
+            transformDirectiveSourceFactory = null;
+        } else {
+            try {
+                transformDirectiveSourceFactory = mockRepo.transformDirectiveSource()
+                        .getDeclaredConstructor()
+                        .newInstance();
+            } catch (ReflectiveOperationException e) {
+                throw new IllegalStateException(
+                        mockRepo.transformDirectiveSource() + " is missing default constructor");
+            }
+        }
+
+        return new MockArtifactStore(
+                createArchiverManager(), root.toFile(), mockRepo.lazyArchiver(), transformDirectiveSourceFactory);
+    }
+
+    private static ArchiverManager createArchiverManager() {
+        Map<String, Provider<Archiver>> archivers = new HashMap<>(4);
+        archivers.put("jar", JarArchiver::new);
+        archivers.put("zip", ZipArchiver::new);
+        archivers.put("war", WarArchiver::new);
+        archivers.put("ear", EarArchiver::new);
+        return new DefaultArchiverManager(archivers, Map.of(), Map.of());
+    }
+
+    private static RemoteRepository toRemoteRepository(RemoteRepo repo) {
+        return new RemoteRepository.Builder(repo.id(), repo.type(), repo.url()).build();
+    }
+
+    private static LocalRepository toLocalRepository(Directory cacheDirectory) {
+        Path targetDirectory = DirectoryResolver.resolve(cacheDirectory);
+
+        return new LocalRepository(targetDirectory.toFile());
+    }
+
+    private static final class ServerResource implements AutoCloseable {
+
+        private final FileSystemServer server;
+        private final MockRepositoryManagerServer handle;
+
+        ServerResource(FileSystemServer server, MockRepositoryManagerServer handle) {
+            this.server = server;
+            this.handle = handle;
+        }
+
+        MockRepositoryManagerServer getHandle() {
+            return handle;
+        }
+
+        @Override
+        public void close() throws Exception {
+            try {
+                server.finish();
+                server.waitForFinished();
+            } finally {
+                handle.cleanup();
+            }
+        }
+    }
+
+    private static final class RepositorySystemHandler implements Closeable, Supplier<RepositorySystem> {
+
+        private final DefaultRepositorySystem repositorySystem;
+
+        public RepositorySystemHandler(DefaultRepositorySystem repositorySystem) {
+            this.repositorySystem = repositorySystem;
+        }
+
+        @Override
+        public RepositorySystem get() {
+            return repositorySystem;
+        }
+
+        @Override
+        public void close() throws IOException {
+            repositorySystem.shutdown();
+        }
+    }
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManagerServer.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManagerServer.java
@@ -62,7 +62,7 @@ public class MockRepositoryManagerServer {
      * @param fileExtension the file extension
      * @return the url to access this artifact
      */
-    public String getUrl(String groupId, String artifactId, String version, String fileExtension) {
+    public String getArtifactUrl(String groupId, String artifactId, String version, String fileExtension) {
         return url
                 + '/'
                 + groupId.replace('.', '/')
@@ -88,7 +88,8 @@ public class MockRepositoryManagerServer {
      * @param classifier the classifier
      * @return the url to access this artifact
      */
-    public String getUrl(String groupId, String artifactId, String version, String fileExtension, String classifier) {
+    public String getArtifactUrl(
+            String groupId, String artifactId, String version, String fileExtension, String classifier) {
         return url
                 + '/'
                 + groupId.replace('.', '/')
@@ -104,6 +105,14 @@ public class MockRepositoryManagerServer {
                 + classifier
                 + '.'
                 + fileExtension;
+    }
+
+    public String getMetadataUrl(String groupId, String file) {
+        return url + '/' + groupId.replace('.', '/') + '/' + file;
+    }
+
+    public String getMetadataUrl(String groupId, String artifactId, String file) {
+        return url + '/' + groupId.replace('.', '/') + '/' + artifactId + '/' + file;
     }
 
     /**

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManagerServer.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManagerServer.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * This instance will be available as argument for tests for classes marked with {@link MockRepositoryManager}
+ *
+ * @since 2.0.0
+ */
+public class MockRepositoryManagerServer {
+
+    private static final String SETTINGS_TEMPLATE_RESOURCE = "/org/codehaus/mojo/mrm/jupiter/settings.xml";
+
+    private static final String SETTINGS_URL_TOKEN = "${mrm.repository.url}";
+
+    private final String url;
+
+    private Path settingsFile;
+
+    MockRepositoryManagerServer(String url) {
+        this.url = url;
+    }
+
+    /**
+     * Returns the base URL of the running Mock Repository Manager server.
+     *
+     * @return the server URL, e.g. {@code http://localhost:8080}
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * Calculate the full URL to a specific artifact
+     *
+     * @param groupId the groupId
+     * @param artifactId the artifactId
+     * @param version the version
+     * @param fileExtension the file extension
+     * @return the url to access this artifact
+     */
+    public String getUrl(String groupId, String artifactId, String version, String fileExtension) {
+        return url
+                + '/'
+                + groupId.replace('.', '/')
+                + '/'
+                + artifactId
+                + '/'
+                + version
+                + '/'
+                + artifactId
+                + '-'
+                + version
+                + '.'
+                + fileExtension;
+    }
+
+    /**
+     * Calculate the full URL to a specific artifact
+     *
+     * @param groupId the groupId
+     * @param artifactId the artifactId
+     * @param version the version
+     * @param fileExtension the file extension
+     * @param classifier the classifier
+     * @return the url to access this artifact
+     */
+    public String getUrl(String groupId, String artifactId, String version, String fileExtension, String classifier) {
+        return url
+                + '/'
+                + groupId.replace('.', '/')
+                + '/'
+                + artifactId
+                + '/'
+                + version
+                + '/'
+                + artifactId
+                + '-'
+                + version
+                + '-'
+                + classifier
+                + '.'
+                + fileExtension;
+    }
+
+    /**
+     * Returns the path to a generated temporary Maven {@code settings.xml} file configured to use this server.
+     * The file is created lazily on first call and reused afterwards for this server handle.
+     *
+     * @return absolute path to the generated Maven settings file
+     */
+    public synchronized Path getSettingsFile() {
+        if (settingsFile == null) {
+            try {
+                settingsFile = createSettingsFile();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        return settingsFile;
+    }
+
+    synchronized void cleanup() {
+        if (settingsFile != null) {
+            try {
+                Files.deleteIfExists(settingsFile);
+            } catch (IOException cleanupError) { // best-effort cleanup; deleteOnExit fallback avoids leaking temp files
+                settingsFile.toFile().deleteOnExit();
+            }
+            settingsFile = null;
+        }
+    }
+
+    private Path createSettingsFile() throws IOException {
+        Path tempSettingsFile = Files.createTempFile("mrm-settings-", ".xml");
+        tempSettingsFile.toFile().deleteOnExit();
+
+        try (InputStream is = MockRepositoryManagerServer.class.getResourceAsStream(SETTINGS_TEMPLATE_RESOURCE);
+                InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
+                BufferedReader reader = new BufferedReader(isr);
+                BufferedWriter writer = Files.newBufferedWriter(tempSettingsFile, StandardCharsets.UTF_8)) {
+
+            String line;
+            boolean isFirstLine = true;
+
+            while ((line = reader.readLine()) != null) {
+                if (!isFirstLine) {
+                    writer.newLine();
+                }
+                isFirstLine = false;
+
+                writer.write(line.replace(SETTINGS_URL_TOKEN, url));
+            }
+        }
+
+        return tempSettingsFile;
+    }
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/NoOpTransformDirectiveSourceFactory.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/NoOpTransformDirectiveSourceFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.nio.file.Path;
+
+import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSource;
+import org.codehaus.mojo.mrm.impl.transform.TransformDirectiveSourceFactory;
+
+/**
+ * This is just a placeholder for annotations
+ *
+ * @since 2.0.0
+ */
+final class NoOpTransformDirectiveSourceFactory implements TransformDirectiveSourceFactory {
+
+    private NoOpTransformDirectiveSourceFactory() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String name() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TransformDirectiveSource newInstance(Path root) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/PathResolver.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/PathResolver.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.nio.file.Path;
+
+/**
+ * @since 2.0.0
+ */
+public interface PathResolver {
+
+    Path resolve();
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/RemoteArtifactSystem.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/RemoteArtifactSystem.java
@@ -21,11 +21,15 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
+ * This is the equivalent of the ProxyRepo as available for the maven-plugin.
+ * The maven-plugin has direct access to the pom, hence to all configured remote repositories.
+ * This extension has no access to build-information, so use this annotation to provide that.
+ *
  * @since 2.0.0
  */
 @Retention(RUNTIME)
 @Target({})
-public @interface RemoteRepositories {
+public @interface RemoteArtifactSystem {
 
     /**
      * The cache directory for all remote repositories

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/RemoteRepo.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/RemoteRepo.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import org.eclipse.aether.repository.RemoteRepository;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation based representation of {@link RemoteRepository}
+ *
+ * @since 2.0.0
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface RemoteRepo {
+
+    String id();
+
+    String type();
+
+    String url();
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/RemoteRepositories.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/RemoteRepositories.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * @since 2.0.0
+ */
+@Retention(RUNTIME)
+@Target({})
+public @interface RemoteRepositories {
+
+    /**
+     * The cache directory for all remote repositories
+     *
+     * For using Mavens default localRepository, set it to {@code @Directory( value = ".m2/repository", baseBathResolver = UserHomePathResolver.class ) }
+     *
+     * @return the shared
+     *
+     * @see UserHomePathResolver
+     */
+    Directory cacheDirectory();
+
+    /**
+     * The remote repositories, which is empty by default, not even the link to Maven Central
+     *
+     * For Maven projects, the default remote repository (Maven Central) is configured in the super-pom as
+     * provided by the Maven buildtool itself.
+     *
+     * Since this extension is not aware of any buildtool, you need it to provide it yourself, e.g. {@code @RemoteRepo( id = "central", "type" = "default", url = "https://repo.maven.apache.org/m2" )}
+     *
+     * @return the remote repositories
+     */
+    RemoteRepo[] repositories();
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/SourcePathResolver.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/SourcePathResolver.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.nio.file.Path;
+
+/**
+ * This is a placeholder class, to mark the output the same as the input
+ */
+class SourcePathResolver implements PathResolver {
+
+    private SourcePathResolver() {}
+
+    @Override
+    public Path resolve() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/StandaloneFactoryHelper.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/StandaloneFactoryHelper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.util.List;
+
+import org.apache.maven.archetype.ArchetypeManager;
+import org.codehaus.mojo.mrm.plugin.FactoryHelper;
+import org.codehaus.plexus.archiver.manager.ArchiverManager;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+
+class StandaloneFactoryHelper implements FactoryHelper {
+
+    private final ArchiverManager archiverManager;
+
+    private final RepositorySystem repositorySystem;
+
+    private final RepositorySystemSession repositorySystemSession;
+
+    private final List<RemoteRepository> remoteRepositories;
+
+    public StandaloneFactoryHelper(
+            RepositorySystem repositorySystem,
+            RepositorySystemSession repositorySystemSession,
+            List<RemoteRepository> remoteRepositories,
+            ArchiverManager archiverManager) {
+        this.repositorySystem = repositorySystem;
+        this.repositorySystemSession = repositorySystemSession;
+        this.remoteRepositories = remoteRepositories;
+        this.archiverManager = archiverManager;
+    }
+
+    @Override
+    public RepositorySystem getRepositorySystem() {
+        return repositorySystem;
+    }
+
+    @Override
+    public RepositorySystemSession getRepositorySystemSession() {
+        return repositorySystemSession;
+    }
+
+    @Override
+    public List<RemoteRepository> getRemoteRepositories() {
+        return remoteRepositories;
+    }
+
+    @Override
+    public ArchetypeManager getArchetypeManager() {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
+    public ArchiverManager getArchiverManager() {
+        return archiverManager;
+    }
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/UserDirPathResolver.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/UserDirPathResolver.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.nio.file.Path;
+
+public class UserDirPathResolver implements PathResolver {
+
+    @Override
+    public Path resolve() {
+        return Path.of(System.getProperty("user.dir"));
+    }
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/UserHomePathResolver.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/UserHomePathResolver.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.nio.file.Path;
+
+public class UserHomePathResolver implements PathResolver {
+
+    @Override
+    public Path resolve() {
+        return Path.of(System.getProperty("user.home"));
+    }
+}

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/package-info.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@org.jspecify.annotations.NullMarked
+package org.codehaus.mojo.mrm.jupiter;

--- a/mrm-jupiter-extension/src/main/resources/org/codehaus/mojo/mrm/jupiter/settings.xml
+++ b/mrm-jupiter-extension/src/main/resources/org/codehaus/mojo/mrm/jupiter/settings.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>mrm-jupiter</id>
+      <url>${mrm.repository.url}</url>
+      <mirrorOf>*</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>

--- a/mrm-jupiter-extension/src/site/markdown/index.md
+++ b/mrm-jupiter-extension/src/site/markdown/index.md
@@ -1,0 +1,35 @@
+title: Introduction
+
+<!---
+Copyright 2026 Robert Scholte
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Mock Repository Manager Jupiter Extension
+
+The Mock Repository Manager Jupiter Extension is used when you want to test against specific sets of dependencies
+in a repository.
+
+## Usage
+
+General instructions on how to use the Mock Repository Manager Jupiter Extension can be found on the [usage page](./usage.html).
+For information about the different repository types and their configuration options, see [Repository Types](./repositories.html).
+Some more specific use cases are described in the examples given below.
+
+In case you still have questions regarding the extension's usage, please have feel free to contact the [user mailing list](./mailing-lists.html). The posts to the mailing list are archived and could
+already contain the answer to your question as part of an older thread. Hence, it is also worth browsing/searching the [mail archive](./mailing-lists.html).
+
+If you feel like the extension is missing a feature or has a defect, you can fill a feature request or bug report in our [issue tracker](./issue-management.html). When creating a new issue, please provide a comprehensive description of your concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this reason, entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
+
+Of course, patches are welcome, too. Contributors can check out the project from our [guide to helping with Maven source repository](./scm.html) and will find supplementary information in the https://maven.apache.org/guides/development/guide-helping.html).

--- a/mrm-jupiter-extension/src/site/markdown/repositories.md
+++ b/mrm-jupiter-extension/src/site/markdown/repositories.md
@@ -1,0 +1,181 @@
+title: Repository Types
+
+<!---
+Copyright MojoHaus and contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+Repository Types
+================
+
+The `MockRepositoryManager` annotation allows you to configure one or more repository types that the Mock Repository Manager will serve. When multiple repositories are specified, they are merged into a single view.
+
+Make sure at least one repository is configured.
+
+## Available Repository Types
+
+### @MockRepo
+
+A mock Maven repository that serves content from a local directory structure with specific file patterns.
+
+**Fields:**
+
+* `source` (required) - The directory containing the mock repository content
+* `cloneTo` (optional) - Clone the source to a specific directory (useful for directory-based archives)
+* `cloneClean` (optional) - Ensure the cloneTo folder is cleaned before every run (default: false)
+* `lazyArchiver` (optional) - Set to `false` to archive directories at startup, or `true` to archive when used (default: false)
+* `transformDirectiveSource` (optional) - Set the name of the mechanism to transform files in case of a directory based archive. Possible values: `metadata` (default: null)
+
+**Example:**
+
+```java
+@MockRepositoryManager(
+    mockRepos = @MockRepo(
+        source = @Directory("src/it/mrm/repository"),
+        cloneTo = @Directory("target/mock-repo"),
+        cloneClean = true,
+        lazyArchiver = false,
+        transformDirectiveSource = MetadataTransformDirectiveFactory.class)
+    )
+)
+```
+
+**Supported File Patterns:**
+
+The mockRepo recognizes the following file patterns in the source directory:
+
+* `**/*.pom` - Maven POM files
+* `**/*-{classifier}.{type}` - Artifacts with classifiers (e.g., `mojo-parent-10-site.xml`)
+* `**/*.{archiver extension}` - Directory archives using the GAV from the corresponding POM
+* `**/*-{classifier}.{archiver extension}` - Directory archives with classifiers
+* `archetype-catalog.xml` - Archetype catalog
+
+Supported archiver extensions include: `jar`, `zip`, `tar.gz`, `tgz`, `tar.xz`, and other formats supported by [Plexus Archiver](https://codehaus-plexus.github.io/plexus-archiver/).
+
+**Supported TransformDirectiveSource:**
+
+* `MetadataTransformDirectiveFactory.class` - Put a file called `.mrm-transform.properties` in the root of an archive directory (e.g. `artifactId-1.0.0.jar/.mrm-transform.properties`). This file supports the following entries
+  * [input].targetName = [output]
+  * [input].contentTransformers = javaToClass
+
+  The `javaToClass` currently supports transforming `module-info.java`, only including `[open]* module MODULENAME` and `requires [static|transitive]* MODULENAME`.
+
+### @LocalRepo
+
+A locally stored Maven repository that serves content from a directory on the filesystem.
+
+**Fields:**
+
+* `source` (required) - The directory containing the local repository (standard Maven repository layout)
+
+**Example:**
+
+```java
+@MockRepositoryManager(
+    localRepos = @LocalRepo(
+        source = @Directory("src/it/resources/local-repo/repositories")
+    )
+)
+```
+
+**Use Cases:**
+
+* Using an existing local repository as a test repository
+* Combining with other repository types to provide additional artifacts
+
+### @HostedRepo
+
+A repository used for distribution management that accepts uploaded artifacts (writable repository).
+
+**Parameters:**
+
+* `target` (required) - The directory where uploaded files will be stored
+
+**Example:**
+
+```java
+@MockRepositoryManager(
+		hostedRepos = @HostedRepo(
+				target = @Directory("target/hosted-repo")
+		)
+)
+
+```
+
+**Use Cases:**
+
+* Testing artifact deployment
+* Testing distribution management configuration
+* Verifying that artifacts are correctly uploaded
+
+**Note:** This repository type is writable, unlike the other repository types which are read-only.
+
+### @RemoteArtifactSystem
+
+A remoteArtifactSystem serves content from remote repositories.
+
+**Fields:**
+
+* `cacheDirectory` (required) - The directory where uploaded files will be stored
+
+* `repositories` (required) - The remote repositories to use when trying to locate an artifact
+
+**Example:**
+
+```java
+@MockRepositoryManager(
+        remoteArtifactSystem =
+                @RemoteArtifactSystem(
+                        cacheDirectory = @Directory("target/remote-repositories"),
+                        repositories =
+                                @RemoteRepo(
+                                        id = "central",
+                                        type = "default",
+                                        url = "https://repo.maven.apache.org/maven2")))
+```
+
+**Use Cases:**
+
+This is useful for providing access to Maven Central and other remote repositories during integration tests.
+
+## Combining Multiple Repositories
+
+You can combine multiple repository types to create a composite view:
+
+```java
+@MockRepositoryManager(
+		mockRepos = @MockRepo(
+				source = @Directory("src/it/mrm/repository")), 
+		localRepos = @LocalRepo(
+				source = @Directory("src/it/resources/local-repo/repositories")), 
+		hostedRepos = @HostedRepo(
+				target = @Directory("target/hosted-repo")), 
+		remoteArtifactSystem = @RemoteArtifactSystem(
+				cacheDirectory = @Directory("target/remote-repositories"), 
+				repositories = @RemoteRepo(
+						id = "central", 
+						type = "default", 
+						url = "https://repo.maven.apache.org/maven2")))
+```
+
+When multiple repositories are configured, the Mock Repository Manager searches them in the following order:
+
+1. mockRepos
+
+2. localRepos
+
+3. hostedRepos
+
+4. remoteArtifactSystem
+

--- a/mrm-jupiter-extension/src/site/markdown/usage.md.vm
+++ b/mrm-jupiter-extension/src/site/markdown/usage.md.vm
@@ -1,0 +1,61 @@
+title: Usage
+author: Robert Scholte
+date: 2026-07-27
+
+<!---
+Copyright 2026 Robert Scholte
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+Usage
+=====
+
+The jupiter extension offers annotations for hosting a mock repository manager as part of a Jupiter Test Lifecycle.
+
+```xml
+<project>
+  ...
+  <dependencies>
+    ...
+      <dependency>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>mrm-jupiter-extension</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+      </dependency>
+    ...
+  </dependencies>
+  ...
+</project>
+```
+
+Basic Usage
+-----------
+
+Write your unit test as usual and annotate the class with @MockRepositoryManager.
+Tests that depend on the mock repository manager should add the MockRepositoryManagerServer parameter to their method.
+
+
+To make use of of it, start writing a unit test as follows:
+
+
+```java
+@MockRepositoryManager
+class ExampleTest {
+
+  @Test
+  void example(MockRepositoryManagerServer server) {
+  
+  }
+}

--- a/mrm-jupiter-extension/src/site/site.xml
+++ b/mrm-jupiter-extension/src/site/site.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright 2011 Stephen Connolly
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 http://maven.apache.org/xsd/decoration-1.8.0.xsd"
+         name="Mock Repository Manager Jupiter Extension">
+  <body>
+    <menu ref="parent"/>
+
+    <menu name="Overview">
+      <item name="Introduction" href="index.html"/>
+      <item name="Usage" href="usage.html"/>
+      <item name="Repository Types" href="repositories.html"/>
+    </menu>
+
+  </body>
+</project>

--- a/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/CustomBasePathIT.java
+++ b/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/CustomBasePathIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import io.restassured.RestAssured;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Based on /mrm-maven-plugin/src/it/custom-base-path/src/it/resolve/src/test/java/org/codehaus/mojo/mrm/plugin/it/resolve/CustomBasePathTest.java
+ */
+@MockRepositoryManager(
+        basePath = "/foo/bar",
+        remoteRepositories =
+                @RemoteRepositories(
+                        cacheDirectory = @Directory(value = ".m2", baseBathResolver = UserHomePathResolver.class),
+                        repositories =
+                                @RemoteRepo(
+                                        id = "central",
+                                        type = "default",
+                                        url = "https://repo.maven.apache.org/maven2")))
+public class CustomBasePathIT {
+
+    @Test
+    void customBasePath(MockRepositoryManagerServer server) {
+        final String mrmUri = server.getUrl();
+
+        /* Make sure the repo ends with the base path we have set in mrm-maven-plugin/src/it/custom-base-path/pom.xml */
+        Assertions.assertThat(mrmUri).endsWith("foo/bar");
+
+        String artifactUrl = server.getUrl("org.apache.commons", "commons-lang3", "3.12.0", "pom");
+
+        /* Try to download something and make sure the content is as expected */
+        String body = RestAssured.get(artifactUrl)
+                .then()
+                .statusCode(200)
+                .extract()
+                .response()
+                .asString();
+
+        assertTrue(body.contains("<artifactId>commons-lang3</artifactId>"));
+        assertTrue(body.contains("<version>3.12.0</version>"));
+    }
+}

--- a/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/CustomBasePathIT.java
+++ b/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/CustomBasePathIT.java
@@ -26,8 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @MockRepositoryManager(
         basePath = "/foo/bar",
-        remoteRepositories =
-                @RemoteRepositories(
+        remoteArtifactSystem =
+                @RemoteArtifactSystem(
                         cacheDirectory = @Directory(value = ".m2", baseBathResolver = UserHomePathResolver.class),
                         repositories =
                                 @RemoteRepo(
@@ -43,7 +43,7 @@ public class CustomBasePathIT {
         /* Make sure the repo ends with the base path we have set in mrm-maven-plugin/src/it/custom-base-path/pom.xml */
         Assertions.assertThat(mrmUri).endsWith("foo/bar");
 
-        String artifactUrl = server.getUrl("org.apache.commons", "commons-lang3", "3.12.0", "pom");
+        String artifactUrl = server.getArtifactUrl("org.apache.commons", "commons-lang3", "3.12.0", "pom");
 
         /* Try to download something and make sure the content is as expected */
         String body = RestAssured.get(artifactUrl)

--- a/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/HostedRepoIT.java
+++ b/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/HostedRepoIT.java
@@ -1,0 +1,49 @@
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MockRepositoryManager(hostedRepos = @HostedRepo(target = @Directory("target/hosted-repo")))
+public class HostedRepoIT {
+
+    @Test
+    void mainArtifact(MockRepositoryManagerServer server) throws Exception {
+        final String mainArtifactUrl = server.getArtifactUrl("dev.groupid", "artifactid", "4.2", "txt");
+
+        RestAssured.given()
+                .body("Downloaded artifactid-4.2.txt successfully")
+                .contentType(ContentType.TEXT)
+                .put(mainArtifactUrl)
+                .then()
+                .statusCode(200);
+
+        String mainContent =
+                Files.readString(Path.of("target/hosted-repo/dev/groupid/artifactid/4.2/artifactid-4.2.txt"));
+
+        assertEquals("Downloaded artifactid-4.2.txt successfully", mainContent);
+    }
+
+    @Test
+    void classifiedArtifact(MockRepositoryManagerServer server) throws Exception {
+        final String classifierArtifactUrl =
+                server.getArtifactUrl("dev.groupid", "artifactid", "4.2", "properties", "meta");
+
+        RestAssured.given()
+                .body("download.artifactid-4.2-meta.properties=success")
+                .contentType(ContentType.TEXT)
+                .put(classifierArtifactUrl)
+                .then()
+                .statusCode(200);
+
+        String classifiedContent = Files.readString(
+                Path.of("target/hosted-repo/dev/groupid/artifactid/4.2/artifactid-4.2-meta.properties"));
+
+        assertEquals("download.artifactid-4.2-meta.properties=success", classifiedContent);
+    }
+}

--- a/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/LocalRepoIT.java
+++ b/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/LocalRepoIT.java
@@ -32,6 +32,6 @@ public class LocalRepoIT {
                 .extract()
                 .asString();
 
-        assertEquals("downdload.artifactid-4.2-meta.properties=success", classifiedContent);
+        assertEquals("download.artifactid-4.2-meta.properties=success", classifiedContent);
     }
 }

--- a/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/LocalRepoIT.java
+++ b/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/LocalRepoIT.java
@@ -1,20 +1,16 @@
-package org.codehaus.mojo.mrm.jupiter.mockrepo;
+package org.codehaus.mojo.mrm.jupiter;
 
 import io.restassured.RestAssured;
-import org.codehaus.mojo.mrm.jupiter.Directory;
-import org.codehaus.mojo.mrm.jupiter.LocalRepo;
-import org.codehaus.mojo.mrm.jupiter.MockRepositoryManager;
-import org.codehaus.mojo.mrm.jupiter.MockRepositoryManagerServer;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @MockRepositoryManager(localRepos = @LocalRepo(source = @Directory("src/it/resources/local-repo/repositories")))
-public class LocalRepoDefaults {
+public class LocalRepoIT {
 
     @Test
-    void defaults(MockRepositoryManagerServer server) {
-        final String mainArtifactUrl = server.getUrl("dev.groupid", "artifactid", "4.2", "txt");
+    void mainArtifact(MockRepositoryManagerServer server) {
+        final String mainArtifactUrl = server.getArtifactUrl("dev.groupid", "artifactid", "4.2", "txt");
 
         String mainContent = RestAssured.get(mainArtifactUrl)
                 .then()
@@ -23,8 +19,12 @@ public class LocalRepoDefaults {
                 .asString();
 
         assertEquals("Downloaded artifactid-4.2.txt successfully", mainContent);
+    }
 
-        final String classifierArtifactUrl = server.getUrl("dev.groupid", "artifactid", "4.2", "properties", "meta");
+    @Test
+    void classifiedArtifact(MockRepositoryManagerServer server) {
+        final String classifierArtifactUrl =
+                server.getArtifactUrl("dev.groupid", "artifactid", "4.2", "properties", "meta");
 
         String classifiedContent = RestAssured.get(classifierArtifactUrl)
                 .then()

--- a/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/MavenRepositories.java
+++ b/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/MavenRepositories.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This shows how a MRM would be configured with Maven defaults
+ */
+@MockRepositoryManager(
+        localRepos =
+                @LocalRepo(
+                        source = @Directory(value = ".m2/repositories", baseBathResolver = UserHomePathResolver.class)),
+        remoteArtifactSystem =
+                @RemoteArtifactSystem(
+                        cacheDirectory =
+                                @Directory(value = ".m2/repositories", baseBathResolver = UserHomePathResolver.class),
+                        repositories =
+                                @RemoteRepo(
+                                        id = "central",
+                                        type = "default",
+                                        url = "https://repo.maven.apache.org/maven2")))
+public class MavenRepositories {
+
+    @Test
+    void mainArtifact(MockRepositoryManagerServer server) throws Exception {
+        var mainArtifact = server.getArtifactUrl("org.codehaus.mojo", "mrm", "1.7.1", "pom");
+        RestAssured.head(mainArtifact).then().statusCode(200);
+    }
+
+    @Test
+    void classifiedArtifact(MockRepositoryManagerServer server) throws Exception {
+        var classifiedArtifact = server.getArtifactUrl("org.codehaus.mojo", "mrm", "1.7.1", "zip", "source-release");
+        RestAssured.head(classifiedArtifact).then().statusCode(200);
+    }
+
+    @Test
+    void groupIdMetadata(MockRepositoryManagerServer server) throws Exception {
+        var groupIdMetadata = server.getMetadataUrl("org.codehaus.mojo", "maven-metadata.xml");
+        RestAssured.head(groupIdMetadata).then().statusCode(200);
+    }
+
+    @Test
+    void artifactIdMetadata(MockRepositoryManagerServer server) throws Exception {
+        var artifactIdMetadata = server.getMetadataUrl("org.codehaus.mojo", "mrm", "maven-metadata.xml");
+        RestAssured.head(artifactIdMetadata).then().statusCode(200);
+    }
+}

--- a/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/RemoteArtifactSystemIT.java
+++ b/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/RemoteArtifactSystemIT.java
@@ -1,0 +1,35 @@
+package org.codehaus.mojo.mrm.jupiter;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@MockRepositoryManager(
+        remoteArtifactSystem =
+                @RemoteArtifactSystem(
+                        cacheDirectory = @Directory("target/remote-repositories"),
+                        repositories =
+                                @RemoteRepo(
+                                        id = "central",
+                                        type = "default",
+                                        url = "https://repo.maven.apache.org/maven2")))
+class RemoteArtifactSystemIT {
+
+    @Test
+    void mainArtifact(MockRepositoryManagerServer server) throws Exception {
+        Path artifactPath = Path.of("target/remote-repositories", "org/codehaus/mojo/mrm/1.7.1/mrm-1.7.1.pom");
+
+        if (Files.exists(artifactPath)) {
+            Files.delete(artifactPath);
+        }
+
+        String mainArtifact = server.getArtifactUrl("org.codehaus.mojo", "mrm", "1.7.1", "pom");
+        RestAssured.get(mainArtifact).then().statusCode(200);
+
+        assertTrue(Files.exists(artifactPath));
+    }
+}

--- a/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/mockrepo/DirectoryTransformIT.java
+++ b/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/mockrepo/DirectoryTransformIT.java
@@ -40,11 +40,11 @@ public class DirectoryTransformIT {
 
     @Test
     void moduleDescriptor(MockRepositoryManagerServer server) throws Exception {
-        final String artifactPomUrl = server.getUrl("localhost", "directory-transform", "1.0", "pom");
+        final String artifactPomUrl = server.getArtifactUrl("localhost", "directory-transform", "1.0", "pom");
 
         RestAssured.get(artifactPomUrl).then().statusCode(200);
 
-        final String artifactJarUrl = server.getUrl("localhost", "directory-transform", "1.0", "jar");
+        final String artifactJarUrl = server.getArtifactUrl("localhost", "directory-transform", "1.0", "jar");
 
         InputStream jarInputStream = RestAssured.get(artifactJarUrl)
                 .then()

--- a/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/mockrepo/DirectoryTransformIT.java
+++ b/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/mockrepo/DirectoryTransformIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Robert Scholte
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.mojo.mrm.jupiter.mockrepo;
+
+import java.io.InputStream;
+import java.util.jar.JarEntry;
+import java.util.jar.JarInputStream;
+
+import io.restassured.RestAssured;
+import org.codehaus.mojo.mrm.impl.transform.metadata.MetadataTransformDirectiveFactory;
+import org.codehaus.mojo.mrm.jupiter.Directory;
+import org.codehaus.mojo.mrm.jupiter.MockRepo;
+import org.codehaus.mojo.mrm.jupiter.MockRepositoryManager;
+import org.codehaus.mojo.mrm.jupiter.MockRepositoryManagerServer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MockRepositoryManager(
+        mockRepos =
+                @MockRepo(
+                        source = @Directory("src/it/resources/mock-repo/directory-transform"),
+                        cloneTo = @Directory("target/it/mock-repo/directory-transform"),
+                        transformDirectiveSource = MetadataTransformDirectiveFactory.class))
+public class DirectoryTransformIT {
+
+    @Test
+    void moduleDescriptor(MockRepositoryManagerServer server) throws Exception {
+        final String artifactPomUrl = server.getUrl("localhost", "directory-transform", "1.0", "pom");
+
+        RestAssured.get(artifactPomUrl).then().statusCode(200);
+
+        final String artifactJarUrl = server.getUrl("localhost", "directory-transform", "1.0", "jar");
+
+        InputStream jarInputStream = RestAssured.get(artifactJarUrl)
+                .then()
+                .statusCode(200)
+                .extract()
+                .response()
+                .asInputStream();
+
+        try (JarInputStream inputStream = new JarInputStream(jarInputStream)) {
+
+            boolean hasClass = false;
+            boolean hasJava = false;
+
+            JarEntry entry;
+            while ((entry = inputStream.getNextJarEntry()) != null) {
+                String name = entry.getName();
+
+                if (name.equals("module-info.class")) {
+                    hasClass = true;
+                } else if (name.equals("module-info.java")) {
+                    hasJava = true;
+                }
+            }
+
+            assertFalse(hasJava, "module-info.java not expected to be in the jar file");
+            assertTrue(hasClass, "module-info.class expected to be in the jar file");
+        }
+    }
+}

--- a/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/mockrepo/LocalRepoDefaults.java
+++ b/mrm-jupiter-extension/src/test/java/org/codehaus/mojo/mrm/jupiter/mockrepo/LocalRepoDefaults.java
@@ -1,0 +1,37 @@
+package org.codehaus.mojo.mrm.jupiter.mockrepo;
+
+import io.restassured.RestAssured;
+import org.codehaus.mojo.mrm.jupiter.Directory;
+import org.codehaus.mojo.mrm.jupiter.LocalRepo;
+import org.codehaus.mojo.mrm.jupiter.MockRepositoryManager;
+import org.codehaus.mojo.mrm.jupiter.MockRepositoryManagerServer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@MockRepositoryManager(localRepos = @LocalRepo(source = @Directory("src/it/resources/local-repo/repositories")))
+public class LocalRepoDefaults {
+
+    @Test
+    void defaults(MockRepositoryManagerServer server) {
+        final String mainArtifactUrl = server.getUrl("dev.groupid", "artifactid", "4.2", "txt");
+
+        String mainContent = RestAssured.get(mainArtifactUrl)
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        assertEquals("Downloaded artifactid-4.2.txt successfully", mainContent);
+
+        final String classifierArtifactUrl = server.getUrl("dev.groupid", "artifactid", "4.2", "properties", "meta");
+
+        String classifiedContent = RestAssured.get(classifierArtifactUrl)
+                .then()
+                .statusCode(200)
+                .extract()
+                .asString();
+
+        assertEquals("downdload.artifactid-4.2-meta.properties=success", classifiedContent);
+    }
+}

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/ProxyArtifactStore.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/ProxyArtifactStore.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -74,7 +75,7 @@ public class ProxyArtifactStore extends BaseArtifactStore {
 
     private final RepositorySystemSession repositorySystemSession;
 
-    private final ArchetypeManager archetypeManager;
+    private final Supplier<ArchetypeManager> archetypeManager;
 
     /**
      * Creates a new instance.
@@ -83,7 +84,7 @@ public class ProxyArtifactStore extends BaseArtifactStore {
      */
     public ProxyArtifactStore(FactoryHelper factoryHelper) {
         this.repositorySystem = Objects.requireNonNull(factoryHelper.getRepositorySystem());
-        this.archetypeManager = Objects.requireNonNull(factoryHelper.getArchetypeManager());
+        this.archetypeManager = () -> factoryHelper.getArchetypeManager();
         this.repositorySystemSession = Objects.requireNonNull(factoryHelper.getRepositorySystemSession());
         this.remoteRepositories = factoryHelper.getRemoteRepositories();
     }
@@ -325,12 +326,12 @@ public class ProxyArtifactStore extends BaseArtifactStore {
 
     @Override
     public ArchetypeCatalog getArchetypeCatalog() {
-        return archetypeManager.getLocalCatalog(repositorySystemSession);
+        return archetypeManager.get().getLocalCatalog(repositorySystemSession);
     }
 
     @Override
     public long getArchetypeCatalogLastModified() throws ArchetypeCatalogNotFoundException {
-        if (archetypeManager.getLocalCatalog(repositorySystemSession) != null) {
+        if (archetypeManager.get().getLocalCatalog(repositorySystemSession) != null) {
             return System.currentTimeMillis();
         } else {
             throw new ArchetypeCatalogNotFoundException();

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
     <module>mrm-servlet</module>
     <module>mrm-servlet-jetty</module>
     <module>mrm-maven-plugin</module>
+    <module>mrm-jupiter-extension</module>
   </modules>
 
   <scm>
@@ -107,12 +108,6 @@
         <groupId>javax.inject</groupId>
         <artifactId>javax.inject</artifactId>
         <version>1</version>
-        <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.resolver</groupId>
-        <artifactId>maven-resolver-api</artifactId>
-        <version>1.9.27</version>
         <scope>provided</scope>
       </dependency>
       <dependency>
@@ -150,6 +145,38 @@
         <artifactId>maven-settings</artifactId>
         <version>${mavenVersion}</version>
         <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-resolver-provider</artifactId>
+        <version>${mavenVersion}</version>
+      </dependency>
+
+      <!-- maven artifact resolver -->
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-api</artifactId>
+        <version>1.9.27</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-spi</artifactId>
+        <version>1.9.27</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-impl</artifactId>
+        <version>1.9.27</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-connector-basic</artifactId>
+        <version>1.9.27</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-transport-http</artifactId>
+        <version>1.9.27</version>
       </dependency>
 
       <!-- Archetype -->
@@ -296,7 +323,12 @@
               <exclusionFail>true</exclusionFail>
               <ignoredUnusedDeclaredDependencies>
                 <dependency>org.slf4j:slf4j-simple</dependency>
+                <dependency>org.junit.jupiter:junit-jupiter</dependency>
               </ignoredUnusedDeclaredDependencies>
+              <ignoredUsedUndeclaredDependencies>
+                <dependency>org.junit.jupiter:junit-jupiter-api</dependency>
+                <!-- loaded via org.junit.jupiter:junit-jupiter -->
+              </ignoredUsedUndeclaredDependencies>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This is Jupiter Extension variant of the mrm-maven-plugin and should support the same set of features.

Maven Integration Tests that depend on MRM has to use the Maven lifecycle: 
* pre-integration-test : start the MRM server
* integration-test: run the integration tests
* post-integration-test: shut down the MRM server
* verify: verify the results of the integration tests.

Running a single integration test was a challenge.

By introducing this Jupiter Extension the test uses the JUnit Jupiter Lifecycle, making it much easier to run mrm dependend tests.
With this introduction the extension is buildtool UNAWARE. 
This means it has no idea where the local repository is located (as defined in settings.xml or its default)
It is also not aware where the default remote repository is located (i,e. Central as defined in the superpom from Maven)

A test could look like this:

	@MockRepositoryManager(
		localRepos = @LocalRepo(
				source = @Directory(
						value = ".m2/repositories", 
						baseBathResolver = UserHomePathResolver.class)), 
		remoteRepositories = @RemoteRepositories(
				cacheDirectory = @Directory(
						value = ".m2/repositories", 
						baseBathResolver = UserHomePathResolver.class), 
				repositories = @RemoteRepo(
						id = "central", 
						type = "default", 
						url = "https://repo.maven.apache.org/maven2")))
	public class MavenRepositories {
	
		@Test
		void defaults(MockRepositoryManagerServer server) throws Exception {
			var mainArtifact = server.getUrl("org.codehaus.mojo", "mrm", "1.7.1", "pom");
	// asserts
			
			var classifiedArtifact = server.getUrl("org.codehaus.mojo", "mrm", "1.7.1", "zip", "source-release");
	// asserts
		}
	}    







