### PR TITLE
Support unknown types

### DIFF
--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/ProxyArtifactStore.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/ProxyArtifactStore.java
@@ -174,7 +174,8 @@ public class ProxyArtifactStore extends BaseArtifactStore {
                             .resolveArtifact(
                                     repositorySystemSession,
                                     new ArtifactRequest(
-                                            ResolverUtils.createArtifact(repositorySystemSession, artifact),
+                                            ResolverUtils.createArtifact(
+                                                    repositorySystemSession.getArtifactTypeRegistry(), artifact),
                                             remoteRepositories,
                                             getClass().getSimpleName()))
                             .getArtifact())

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/ResolverUtils.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/maven/ResolverUtils.java
@@ -3,8 +3,8 @@ package org.codehaus.mojo.mrm.impl.maven;
 import java.util.Optional;
 
 import org.codehaus.mojo.mrm.api.maven.Artifact;
-import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.ArtifactType;
+import org.eclipse.aether.artifact.ArtifactTypeRegistry;
 
 import static java.util.Optional.ofNullable;
 
@@ -22,24 +22,23 @@ final class ResolverUtils {
      * <p>Future deprecation: This method will be replaced with the new Maven 4
      * {@code org.apache.maven.api.services.ArtifactFactory} once it becomes available.</p>
      *
-     * @param repositorySystemSession {@link RepositorySystemSession} instance, may not be {@code null}
+     * @param artifactTypeRegistry registry of artifactTypes, may not be {@code null}
      * @param artifact object to read the data from, may not be {@code null}
      * @return new {@link org.eclipse.aether.artifact.Artifact} instance
      */
     static org.eclipse.aether.artifact.Artifact createArtifact(
-            RepositorySystemSession repositorySystemSession, Artifact artifact) {
+            ArtifactTypeRegistry artifactTypeRegistry, Artifact artifact) {
         String groupId = artifact.getGroupId();
         String artifactId = artifact.getArtifactId();
         String version = artifact.getTimestampVersion();
 
-        Optional<ArtifactType> artifactType =
-                ofNullable(artifact.getType()).map(repositorySystemSession.getArtifactTypeRegistry()::get);
+        Optional<ArtifactType> artifactType = Optional.ofNullable(artifactTypeRegistry.get(artifact.getType()));
         return new org.eclipse.aether.artifact.DefaultArtifact(
                 groupId,
                 artifactId,
                 ofNullable(artifact.getClassifier())
                         .orElse(artifactType.map(ArtifactType::getClassifier).orElse(null)),
-                artifactType.map(ArtifactType::getExtension).orElse(null),
+                artifactType.map(ArtifactType::getExtension).orElse(artifact.getType()),
                 version,
                 artifactType.orElse(null));
     }

--- a/mrm-servlet/src/test/java/org/codehaus/mojo/mrm/impl/maven/ResolverUtilsTest.java
+++ b/mrm-servlet/src/test/java/org/codehaus/mojo/mrm/impl/maven/ResolverUtilsTest.java
@@ -1,0 +1,58 @@
+package org.codehaus.mojo.mrm.impl.maven;
+
+import org.codehaus.mojo.mrm.api.maven.Artifact;
+import org.eclipse.aether.artifact.ArtifactType;
+import org.eclipse.aether.artifact.DefaultArtifactType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResolverUtilsTest {
+
+    @Test
+    void unknownType() {
+        Artifact mrmArtifact = new Artifact("groupId", "artifactId", "version", "classifier", "type");
+
+        org.eclipse.aether.artifact.Artifact arArtifact = ResolverUtils.createArtifact(t -> null, mrmArtifact);
+
+        assertEquals("groupId", arArtifact.getGroupId());
+        assertEquals("artifactId", arArtifact.getArtifactId());
+        assertEquals("version", arArtifact.getVersion());
+        assertEquals("classifier", arArtifact.getClassifier());
+        assertEquals("type", arArtifact.getExtension());
+    }
+
+    /**
+     * From org.apache.maven.repository.internal.MavenRepositorySystemUtils
+     */
+    @Test
+    void mainType() {
+        ArtifactType type = new DefaultArtifactType("maven-plugin", "jar", "", "java");
+        Artifact mrmArtifact = new Artifact("groupId", "artifactId", "version", "maven-plugin");
+
+        org.eclipse.aether.artifact.Artifact arArtifact = ResolverUtils.createArtifact(t -> type, mrmArtifact);
+
+        assertEquals("groupId", arArtifact.getGroupId());
+        assertEquals("artifactId", arArtifact.getArtifactId());
+        assertEquals("version", arArtifact.getVersion());
+        assertEquals("", arArtifact.getClassifier());
+        assertEquals("jar", arArtifact.getExtension());
+    }
+
+    /**
+     * From org.apache.maven.repository.internal.MavenRepositorySystemUtils
+     */
+    @Test
+    void classifiedType() {
+        ArtifactType type = new DefaultArtifactType("java-source", "jar", "sources", "java", false, false);
+        Artifact mrmArtifact = new Artifact("groupId", "artifactId", "version", "java-source");
+
+        org.eclipse.aether.artifact.Artifact arArtifact = ResolverUtils.createArtifact(t -> type, mrmArtifact);
+
+        assertEquals("groupId", arArtifact.getGroupId());
+        assertEquals("artifactId", arArtifact.getArtifactId());
+        assertEquals("version", arArtifact.getVersion());
+        assertEquals("sources", arArtifact.getClassifier());
+        assertEquals("jar", arArtifact.getExtension());
+    }
+}


### PR DESCRIPTION
If a type was not registered as artifactType, the file extension became null.
This was unwanted behavior, instead it should keep the orignal file extension