### PR TITLE
Apply several Java 17 features

### DIFF
--- a/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/maven/ArchetypeCatalogNotFoundException.java
+++ b/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/maven/ArchetypeCatalogNotFoundException.java
@@ -16,6 +16,8 @@
 
 package org.codehaus.mojo.mrm.api.maven;
 
+import java.io.Serial;
+
 /**
  * An exception that indicates that an artifact could not be found.
  *
@@ -27,6 +29,7 @@ public class ArchetypeCatalogNotFoundException extends Exception {
      *
      * @since 1.0
      */
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/maven/ArtifactNotFoundException.java
+++ b/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/maven/ArtifactNotFoundException.java
@@ -16,6 +16,8 @@
 
 package org.codehaus.mojo.mrm.api.maven;
 
+import java.io.Serial;
+
 /**
  * An exception that indicates that an artifact could not be found.
  *
@@ -27,6 +29,7 @@ public class ArtifactNotFoundException extends Exception {
      *
      * @since 1.0
      */
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/maven/MetadataNotFoundException.java
+++ b/mrm-api/src/main/java/org/codehaus/mojo/mrm/api/maven/MetadataNotFoundException.java
@@ -16,6 +16,8 @@
 
 package org.codehaus.mojo.mrm.api.maven;
 
+import java.io.Serial;
+
 /**
  * An exception that indicates that an artifact could not be found.
  *
@@ -27,6 +29,7 @@ public class MetadataNotFoundException extends Exception {
      *
      * @since 1.0
      */
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/Directory.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/Directory.java
@@ -16,7 +16,6 @@
 package org.codehaus.mojo.mrm.jupiter;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * A reference to a directory.
@@ -39,7 +38,7 @@ public @interface Directory {
      * This value must be relative and must give the same result after normalizing.
      *
      * @return the path
-     * @see Paths#get(String, String...)
+     * @see Path#of(String, String...)
      * @see Path#resolve(String)
      */
     String value();

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManagerServer.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManagerServer.java
@@ -150,7 +150,7 @@ public class MockRepositoryManagerServer {
         try (InputStream is = MockRepositoryManagerServer.class.getResourceAsStream(SETTINGS_TEMPLATE_RESOURCE);
                 InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8);
                 BufferedReader reader = new BufferedReader(isr);
-                BufferedWriter writer = Files.newBufferedWriter(tempSettingsFile, StandardCharsets.UTF_8)) {
+                BufferedWriter writer = Files.newBufferedWriter(tempSettingsFile)) {
 
             String line;
             boolean isFirstLine = true;

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/digest/AutoDigestFileSystem.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/impl/digest/AutoDigestFileSystem.java
@@ -92,17 +92,17 @@ public class AutoDigestFileSystem extends BaseFileSystem {
         Entry[] entries = backing.listEntries(DefaultDirectoryEntry.equivalent(backing, directory));
         for (Entry entry : entries) {
             final String name = entry.getName();
-            if (entry instanceof FileEntry) {
+            if (entry instanceof FileEntry fileEntry) {
                 for (String type : digestFactories.keySet()) {
                     if (name.endsWith(type)) {
                         present.add(name);
                     } else {
-                        missing.put(name + type, (FileEntry) entry);
+                        missing.put(name + type, fileEntry);
                     }
                 }
-                result.put(name, new LinkFileEntry(this, directory, (FileEntry) entry));
-            } else if (entry instanceof DirectoryEntry) {
-                result.put(name, DefaultDirectoryEntry.equivalent(this, (DirectoryEntry) entry));
+                result.put(name, new LinkFileEntry(this, directory, fileEntry));
+            } else if (entry instanceof DirectoryEntry directoryEntry) {
+                result.put(name, DefaultDirectoryEntry.equivalent(this, directoryEntry));
             }
         }
         missing.keySet().removeAll(present);
@@ -165,17 +165,17 @@ public class AutoDigestFileSystem extends BaseFileSystem {
             for (int i = 0; i < parts.length - 1; i++) {
                 parent = new DefaultDirectoryEntry(this, parent, parts[i]);
             }
-            if (entry instanceof FileEntry) {
+            if (entry instanceof FileEntry fileEntry) {
                 // repair filesystems that lie to us because they are caching
                 for (DigestFileEntryFactory factory : digestFactories.values()) {
                     if (entry.getName().endsWith(factory.getType())) {
                         Entry shadow = backing.get(
                                 parent.toPath() + "/" + Strings.CS.removeEnd(entry.getName(), factory.getType()));
                         return new GenerateOnErrorFileEntry(
-                                this, parent, (FileEntry) entry, factory.create(this, parent, (FileEntry) shadow));
+                                this, parent, fileEntry, factory.create(this, parent, (FileEntry) shadow));
                     }
                 }
-                return new LinkFileEntry(this, parent, (FileEntry) entry);
+                return new LinkFileEntry(this, parent, fileEntry);
             } else if (entry instanceof DirectoryEntry) {
                 for (DigestFileEntryFactory factory : digestFactories.values()) {
                     if (entry.getName().endsWith(factory.getType())) {

--- a/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/servlet/FileSystemServlet.java
+++ b/mrm-servlet/src/main/java/org/codehaus/mojo/mrm/servlet/FileSystemServlet.java
@@ -73,8 +73,7 @@ public class FileSystemServlet extends HttpServlet {
         }
 
         Entry entry = fileSystem.get(path);
-        if (entry instanceof FileEntry) {
-            FileEntry fileEntry = (FileEntry) entry;
+        if (entry instanceof FileEntry fileEntry) {
             long size = fileEntry.getSize();
             if (size >= 0 && size < Integer.MAX_VALUE) {
                 resp.setContentLength((int) size);

--- a/mrm-servlet/src/test/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStoreTest.java
+++ b/mrm-servlet/src/test/java/org/codehaus/mojo/mrm/impl/maven/MockArtifactStoreTest.java
@@ -7,7 +7,6 @@ import java.io.InputStream;
 import java.lang.module.ModuleDescriptor;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -68,13 +67,13 @@ class MockArtifactStoreTest extends AbstractTestSupport {
         Artifact pomArtifact = new Artifact("localhost", "mmockrm-7", "1.0", "pom");
         assertNotNull(artifactStore.get(pomArtifact));
         assertTrue(IOUtils.contentEquals(
-                Files.newInputStream(Paths.get("src/test/resources/mmockrm-7/mmockrm-7-1.0.pom")),
+                Files.newInputStream(Path.of("src/test/resources/mmockrm-7/mmockrm-7-1.0.pom")),
                 artifactStore.get(pomArtifact)));
 
         Artifact siteArtifact = new Artifact("localhost", "mmockrm-7", "1.0", "site", "xml");
         assertNotNull(artifactStore.get(siteArtifact));
         assertTrue(IOUtils.contentEquals(
-                Files.newInputStream(Paths.get("src/test/resources/mmockrm-7/mmockrm-7-1.0-site.xml")),
+                Files.newInputStream(Path.of("src/test/resources/mmockrm-7/mmockrm-7-1.0-site.xml")),
                 artifactStore.get(siteArtifact)));
     }
 
@@ -100,7 +99,7 @@ class MockArtifactStoreTest extends AbstractTestSupport {
         Artifact pomArtifact = new Artifact("localhost", "mrm-15", "1.0", "pom");
         assertNotNull(artifactStore.get(pomArtifact));
         assertTrue(IOUtils.contentEquals(
-                Files.newInputStream(Paths.get("target/test-classes/mrm-15/mrm-15-1.0.pom")),
+                Files.newInputStream(Path.of("target/test-classes/mrm-15/mrm-15-1.0.pom")),
                 artifactStore.get(pomArtifact)));
 
         Artifact mainArtifact = new Artifact("localhost", "mrm-15", "1.0", "jar");
@@ -134,8 +133,7 @@ class MockArtifactStoreTest extends AbstractTestSupport {
         InputStream inputStreamPom = artifactStore.get(pomArtifact);
         assertNotNull(inputStreamPom);
         assertTrue(IOUtils.contentEquals(
-                Files.newInputStream(Paths.get("target/test-classes/empty-jar/mrm-empty-jar-1.0.pom")),
-                inputStreamPom));
+                Files.newInputStream(Path.of("target/test-classes/empty-jar/mrm-empty-jar-1.0.pom")), inputStreamPom));
 
         Artifact mainArtifact = new Artifact("localhost", "mrm-empty-jar", "1.0", "jar");
         InputStream inputStreamJar = artifactStore.get(mainArtifact);
@@ -167,7 +165,7 @@ class MockArtifactStoreTest extends AbstractTestSupport {
         InputStream inputStreamPom = artifactStore.get(pomArtifact);
         assertNotNull(inputStreamPom);
         assertTrue(IOUtils.contentEquals(
-                Files.newInputStream(Paths.get("target/test-classes/empty-plugin-jar/mrm-empty-plugin-jar-1.0.pom")),
+                Files.newInputStream(Path.of("target/test-classes/empty-plugin-jar/mrm-empty-plugin-jar-1.0.pom")),
                 inputStreamPom));
 
         Artifact mainArtifact = new Artifact("localhost", "mrm-empty-plugin-jar", "1.0", "jar");
@@ -379,7 +377,7 @@ class MockArtifactStoreTest extends AbstractTestSupport {
         Artifact pomArtifact = new Artifact("localhost", "mrm-xx", "1.0", "pom");
         assertNotNull(artifactStore.get(pomArtifact));
         assertTrue(IOUtils.contentEquals(
-                Files.newInputStream(Paths.get("target/test-classes/mrm-xx/mrm-xx-1.0.pom")),
+                Files.newInputStream(Path.of("target/test-classes/mrm-xx/mrm-xx-1.0.pom")),
                 artifactStore.get(pomArtifact)));
 
         Artifact classifiedArtifact = new Artifact("localhost", "mrm-xx", "1.0", "javadoc-resources", "jar");


### PR DESCRIPTION
With a previous commit the Java version requirement was already changed to 17.

This is the result of running `mvn -U org.openrewrite.maven:rewrite-maven-plugin:run --define rewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-migrate-java:RELEASE --define rewrite.activeRecipes=org.openrewrite.java.migrate.UpgradeToJava17` and excluding the jakarta dependencies.