### PR TITLE
Build the repository system from the supplier, not the service locator

### DIFF
--- a/mrm-jupiter-extension/pom.xml
+++ b/mrm-jupiter-extension/pom.xml
@@ -59,25 +59,12 @@
       <artifactId>maven-resolver-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-spi</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-impl</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-resolver-provider</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-connector-basic</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.resolver</groupId>
-      <artifactId>maven-resolver-transport-http</artifactId>
+      <artifactId>maven-resolver-supplier</artifactId>
     </dependency>
 
     <dependency>

--- a/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManagerExtension.java
+++ b/mrm-jupiter-extension/src/main/java/org/codehaus/mojo/mrm/jupiter/MockRepositoryManagerExtension.java
@@ -50,15 +50,10 @@ import org.codehaus.plexus.archiver.war.WarArchiver;
 import org.codehaus.plexus.archiver.zip.ZipArchiver;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.connector.basic.BasicRepositoryConnectorFactory;
-import org.eclipse.aether.impl.DefaultServiceLocator;
-import org.eclipse.aether.internal.impl.DefaultRepositorySystem;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.LocalRepositoryManager;
 import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.spi.connector.RepositoryConnectorFactory;
-import org.eclipse.aether.spi.connector.transport.TransporterFactory;
-import org.eclipse.aether.transport.http.HttpTransporterFactory;
+import org.eclipse.aether.supplier.RepositorySystemSupplier;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -127,15 +122,7 @@ class MockRepositoryManagerExtension implements BeforeAllCallback, AfterAllCallb
     }
 
     private RepositorySystemHandler createRepositorySystem() {
-        DefaultRepositorySystem repositorySystem = new DefaultRepositorySystem();
-        DefaultServiceLocator serviceLocator = MavenRepositorySystemUtils.newServiceLocator();
-        serviceLocator.addService(RepositoryConnectorFactory.class, BasicRepositoryConnectorFactory.class);
-        // Registreer de HTTP transport factory
-        serviceLocator.addService(TransporterFactory.class, HttpTransporterFactory.class);
-
-        repositorySystem.initService(serviceLocator);
-
-        return new RepositorySystemHandler(repositorySystem);
+        return new RepositorySystemHandler(new RepositorySystemSupplier().get());
     }
 
     private ServerResource createServerSource(
@@ -326,9 +313,9 @@ class MockRepositoryManagerExtension implements BeforeAllCallback, AfterAllCallb
 
     private static final class RepositorySystemHandler implements Closeable, Supplier<RepositorySystem> {
 
-        private final DefaultRepositorySystem repositorySystem;
+        private final RepositorySystem repositorySystem;
 
-        public RepositorySystemHandler(DefaultRepositorySystem repositorySystem) {
+        public RepositorySystemHandler(RepositorySystem repositorySystem) {
             this.repositorySystem = repositorySystem;
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,11 @@
         <artifactId>maven-resolver-transport-http</artifactId>
         <version>${resolverVersion}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.maven.resolver</groupId>
+        <artifactId>maven-resolver-supplier</artifactId>
+        <version>${resolverVersion}</version>
+      </dependency>
 
       <!-- Archetype -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
   <properties>
     <scmpublish.content>${project.build.directory}/staging/mrm</scmpublish.content>
     <mavenVersion>3.9.16</mavenVersion>
+    <resolverVersion>1.9.27</resolverVersion>
     <minimalMavenBuildVersion>3.9.6</minimalMavenBuildVersion>
     <mojo.java.target>17</mojo.java.target>
     <project.build.outputTimestamp>2026-07-10T10:08:48Z</project.build.outputTimestamp>
@@ -164,27 +165,27 @@
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>
         <artifactId>maven-resolver-api</artifactId>
-        <version>1.9.27</version>
+        <version>${resolverVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>
         <artifactId>maven-resolver-spi</artifactId>
-        <version>1.9.27</version>
+        <version>${resolverVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>
         <artifactId>maven-resolver-impl</artifactId>
-        <version>1.9.27</version>
+        <version>${resolverVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>
         <artifactId>maven-resolver-connector-basic</artifactId>
-        <version>1.9.27</version>
+        <version>${resolverVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.resolver</groupId>
         <artifactId>maven-resolver-transport-http</artifactId>
-        <version>1.9.27</version>
+        <version>${resolverVersion}</version>
       </dependency>
 
       <!-- Archetype -->


### PR DESCRIPTION
`MockRepositoryManagerExtension` built its `RepositorySystem` through `MavenRepositorySystemUtils.newServiceLocator()` and `initService`. Resolver 2.x removes `org.eclipse.aether.spi.locator.ServiceLocator` and `Service` outright, which is why #303, #304 and #305 fail to compile:

```
cannot access org.eclipse.aether.spi.locator.ServiceLocator
  class file for org.eclipse.aether.spi.locator.ServiceLocator not found
```

`RepositorySystemSupplier` already ships in 1.9 and wires the basic connector plus the file and http transports, so the manual registration goes with it, and the handler can hold the `RepositorySystem` interface — `shutdown()` has been on it since 1.9.0. Four declarations in `mrm-jupiter-extension` become redundant; `dependency:analyze` flags them, and the supplier brings them transitively.

The first commit is a separate concern: the five resolver artifacts each carried a literal `1.9.27`, so a bump had to move all five in step or leave a mixed stack. They now share `${resolverVersion}`.

Verified: `mvn verify` on each commit → BUILD SUCCESS, including all 9 `mrm-jupiter-extension` ITs, which are what actually construct the repository system. No `ServiceLocator`, `initService` or `spi.locator` reference is left in the tree.

**This does not by itself make #303–#305 mergeable.** The supplier artifact is renamed across the line boundary — `maven-resolver-supplier` on 1.9, `maven-resolver-supplier-mvn3`/`-mvn4` on 2.x — so raising only api, spi and impl would recreate the mixed stack. `maven-resolver-provider` also tracks `mavenVersion` (3.9.16), which pins resolver 1.9 transitively. A 2.x move is gated on the Maven baseline, not on these three bumps. What this change does remove is the API that 2.x deleted.

*This change was created with AI assistance.*