### PR TITLE
Stop dependabot from offering resolver 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
       # Jetty >=10 requires Java 11+
       - dependency-name: "org.eclipse.jetty:*"
         versions: [">= 10.0"]
+      # The resolver line has to match mavenVersion: maven-resolver-provider
+      # 3.9.x pins resolver 1.9 transitively, and the supplier artifact is
+      # renamed across the boundary.
+      - dependency-name: "org.apache.maven.resolver:*"
+        versions: [">= 2.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
#303, #304 and #305 each raise one resolver artifact to 2.0.21 and fail to compile, because resolver 2 removed `org.eclipse.aether.spi.locator.ServiceLocator` and `Service`. #308 removes that usage, but it does not make these three mergeable:

- `maven-resolver-provider` follows `mavenVersion` (3.9.16) and pins resolver 1.9 transitively, so raising three artifacts leaves a mixed stack;
- the supplier artifact is renamed across the line boundary — `maven-resolver-supplier` exists only at 1.9.x, `maven-resolver-supplier-mvn3`/`-mvn4` only at 2.x — so one POM cannot span both without a profile.

A resolver 2 move is gated on the Maven baseline, not on these bumps. With #308 merged the five resolver artifacts share `${resolverVersion}`, so when the baseline does move it is a single property change rather than five PRs.

Supersedes #303, #304, #305.

*This change was created with AI assistance.*